### PR TITLE
Add USPS-verified address autocomplete for client editing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN pip install --no-cache-dir \
     jinja2 \
     python-multipart \
     pydantic \
+    httpx \
     itsdangerous \
     bcrypt
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ stores data, and Docker Compose makes it easy to run everything locally.
   unique barcode, description, acquisition cost and sales price.
 * **Client list** – Load and display a list of clients from a JSON file
   (`client_table.json`).
+* **USPS-verified address autocomplete** – Client address fields can be
+  auto-completed with USPS-certified suggestions when SmartyStreets
+  credentials are provided.
 * **Responsive UI** – HTML pages served with Jinja2 templates and static
   resources provide a simple front‑end for managing tickets, hardware and
   clients.  Sessions and login keep your changes protected.
@@ -132,9 +135,28 @@ The application reads configuration from environment variables defined in
 | `TZ`                | Time zone for timestamps                    | `America/Chicago`    |
 | `SESSION_COOKIE_NAME` | Name of the session cookie                | `tt_session`         |
 | `SESSION_MAX_AGE`   | Session lifetime in seconds                 | `2592000` (30 days)  |
+| `SMARTY_AUTH_ID`    | SmartyStreets Auth ID for USPS address APIs | empty (disabled)     |
+| `SMARTY_AUTH_TOKEN` | SmartyStreets Auth Token                    | empty (disabled)     |
+| `SMARTY_AUTOCOMPLETE_URL` | Override for the autocomplete endpoint | Smarty default       |
+| `SMARTY_STREET_URL` | Override for the verification endpoint      | Smarty default       |
 
 Refer to `app/core/config.py` and `docker-compose.yml` for the full list of
 environment variables and their defaults.
+
+### Address autocomplete setup
+
+Address prefill in the client editor is powered by SmartyStreets' USPS-certified
+APIs. To enable it:
+
+1. Create a (free) SmartyStreets account and generate an **Auth ID** and
+   **Auth Token** for the US Autocomplete Pro and US Street APIs.
+2. Set the `SMARTY_AUTH_ID` and `SMARTY_AUTH_TOKEN` environment variables for
+   the application (for example in `.env` or your Docker Compose file).
+3. Restart the application. When editing a client, typing into **Address Line 1**
+   will display USPS-verified suggestions. Selecting a suggestion automatically
+   fills the remaining city/state/ZIP fields after verification.
+
+If the credentials are omitted, the UI silently falls back to manual entry.
 
 ## Contributing
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -97,6 +97,9 @@ app.include_router(clients_router.router, prefix="")
 from .routers import api_hardware as api_hardware_router  # type: ignore
 app.include_router(api_hardware_router.router, prefix="")
 
+from .routers import address as address_router  # type: ignore
+app.include_router(address_router.router, prefix="")
+
 # ---------- Exception handling ----------
 # Redirect HTML 401s to /login while keeping JSON 401s for API/headless clients.
 @app.exception_handler(StarletteHTTPException)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -32,4 +32,16 @@ class Settings:
     HOST = os.getenv("HOST", "0.0.0.0")
     PORT = int(os.getenv("PORT", "8089"))
 
+    # Address autocomplete (SmartyStreets USPS-verified services)
+    SMARTY_AUTH_ID = os.getenv("SMARTY_AUTH_ID", "")
+    SMARTY_AUTH_TOKEN = os.getenv("SMARTY_AUTH_TOKEN", "")
+    SMARTY_AUTOCOMPLETE_URL = os.getenv(
+        "SMARTY_AUTOCOMPLETE_URL",
+        "https://us-autocomplete-pro.api.smartystreets.com/lookup",
+    )
+    SMARTY_STREET_URL = os.getenv(
+        "SMARTY_STREET_URL",
+        "https://us-street.api.smartystreets.com/street-address",
+    )
+
 settings = Settings()

--- a/app/routers/address.py
+++ b/app/routers/address.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import status
+
+from ..deps.auth import require_ui_or_token
+from ..services.address import (
+    AddressServiceNotConfigured,
+    fetch_autocomplete_suggestions,
+    verify_postal_address,
+)
+
+router = APIRouter(
+    prefix="/api/v1/address",
+    tags=["address"],
+    dependencies=[Depends(require_ui_or_token)],
+)
+
+
+@router.get("/suggest")
+async def suggest_address(
+    q: str = Query(..., min_length=2, alias="query"),
+    city: str | None = Query(default=None),
+    state: str | None = Query(default=None),
+    postal_code: str | None = Query(default=None, alias="zip"),
+    limit: int = Query(default=8, ge=1, le=20),
+):
+    try:
+        suggestions = await fetch_autocomplete_suggestions(
+            q,
+            city=city,
+            state=state,
+            postal_code=postal_code,
+            max_results=limit,
+        )
+    except AddressServiceNotConfigured as exc:  # pragma: no cover - configuration guard
+        raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, str(exc)) from exc
+    return {"suggestions": suggestions}
+
+
+@router.get("/verify")
+async def verify_address(
+    street_line: str = Query(..., alias="street"),
+    city: str | None = Query(default=None),
+    state: str | None = Query(default=None),
+    postal_code: str | None = Query(default=None, alias="zip"),
+    secondary: str | None = Query(default=None),
+):
+    try:
+        candidate = await verify_postal_address(
+            street_line=street_line,
+            city=city,
+            state=state,
+            postal_code=postal_code,
+            secondary=secondary,
+        )
+    except AddressServiceNotConfigured as exc:  # pragma: no cover - configuration guard
+        raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, str(exc)) from exc
+    if not candidate:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Address not verified")
+    return {"candidate": candidate}

--- a/app/services/address.py
+++ b/app/services/address.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from ..core.config import settings
+
+logger = logging.getLogger(__name__)
+
+class AddressServiceNotConfigured(Exception):
+    """Raised when address autocomplete credentials are missing."""
+
+
+def _ensure_configured() -> None:
+    if not settings.SMARTY_AUTH_ID or not settings.SMARTY_AUTH_TOKEN:
+        raise AddressServiceNotConfigured("Address autocomplete is not configured")
+
+
+def _format_zip(components: Dict[str, Any]) -> str:
+    zipcode = (components.get("zipcode") or "").strip()
+    plus4 = (components.get("plus4_code") or "").strip()
+    if zipcode and plus4:
+        return f"{zipcode}-{plus4}"
+    return zipcode
+
+
+async def fetch_autocomplete_suggestions(
+    search: str,
+    *,
+    city: Optional[str] = None,
+    state: Optional[str] = None,
+    postal_code: Optional[str] = None,
+    max_results: int = 10,
+) -> List[Dict[str, Any]]:
+    """Return USPS-verified address suggestions via SmartyStreets Autocomplete Pro."""
+
+    _ensure_configured()
+
+    if not search or not search.strip():
+        return []
+
+    params: Dict[str, Any] = {
+        "search": search.strip(),
+        "auth-id": settings.SMARTY_AUTH_ID,
+        "auth-token": settings.SMARTY_AUTH_TOKEN,
+        "source": "all",
+        "max_results": max_results,
+    }
+
+    if city:
+        params["include_only_cities"] = city
+    if state:
+        params["include_only_states"] = state
+    if postal_code:
+        params["include_only_zip_codes"] = postal_code
+
+    timeout = httpx.Timeout(6.0)
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        response = await client.get(settings.SMARTY_AUTOCOMPLETE_URL, params=params)
+
+    if response.status_code == 401:
+        logger.warning("SmartyStreets authentication failed for address autocomplete")
+        raise httpx.HTTPStatusError("Unauthorized", request=response.request, response=response)
+    if response.status_code >= 500:
+        logger.error("SmartyStreets service error %s", response.status_code)
+        raise httpx.HTTPStatusError("Service unavailable", request=response.request, response=response)
+
+    data = response.json()
+    suggestions: List[Dict[str, Any]] = []
+    for item in data.get("suggestions", []):
+        suggestion = {
+            "street_line": item.get("street_line") or item.get("primary_line"),
+            "secondary": item.get("secondary") or "",
+            "city": item.get("city"),
+            "state": item.get("state"),
+            "postal_code": item.get("zipcode"),
+            "entries": item.get("entries"),
+            "source": item.get("source"),
+        }
+        suggestions.append(suggestion)
+
+    return suggestions
+
+
+async def verify_postal_address(
+    *,
+    street_line: str,
+    city: Optional[str] = None,
+    state: Optional[str] = None,
+    postal_code: Optional[str] = None,
+    secondary: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Verify a selected address via SmartyStreets US Street API."""
+
+    _ensure_configured()
+
+    payload: List[Dict[str, Any]] = [
+        {
+            "street": street_line,
+            "city": city,
+            "state": state,
+            "zipcode": postal_code,
+            "secondary": secondary or None,
+            "candidates": 1,
+        }
+    ]
+
+    timeout = httpx.Timeout(6.0)
+    params = {
+        "auth-id": settings.SMARTY_AUTH_ID,
+        "auth-token": settings.SMARTY_AUTH_TOKEN,
+    }
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        response = await client.post(
+            settings.SMARTY_STREET_URL,
+            params=params,
+            json=payload,
+        )
+
+    if response.status_code == 401:
+        logger.warning("SmartyStreets authentication failed for address verification")
+        raise httpx.HTTPStatusError("Unauthorized", request=response.request, response=response)
+    if response.status_code >= 500:
+        logger.error("SmartyStreets street API error %s", response.status_code)
+        raise httpx.HTTPStatusError("Service unavailable", request=response.request, response=response)
+
+    candidates = response.json()
+    if not candidates:
+        return None
+
+    candidate = candidates[0]
+    components = candidate.get("components") or {}
+
+    verified = {
+        "delivery_line_1": candidate.get("delivery_line_1"),
+        "delivery_line_2": candidate.get("delivery_line_2") or "",
+        "last_line": candidate.get("last_line"),
+        "city": components.get("city_name"),
+        "state": components.get("state_abbreviation"),
+        "postal_code": _format_zip(components),
+        "county": candidate.get("metadata", {}).get("county_name"),
+        "dpv_match_code": candidate.get("analysis", {}).get("dpv_match_code"),
+        "footnotes": candidate.get("analysis", {}).get("footnotes"),
+    }
+    return verified

--- a/app/static/app.css
+++ b/app/static/app.css
@@ -265,6 +265,41 @@ details[open] .note-toggle{ transform:rotate(90deg); }
 .form-block textarea{ width:100%; min-height:110px; resize:vertical; }
 .hardware-snapshot{ margin-top:12px; font-size:0.9rem; color:#444; }
 
+.address-autocomplete{ position:relative; }
+.address-suggestions{
+  position:absolute;
+  inset:calc(100% + 4px) 0 auto 0;
+  background:#fff;
+  border:1px solid var(--line);
+  border-radius:10px;
+  box-shadow:var(--shadow);
+  z-index:50;
+  max-height:240px;
+  overflow-y:auto;
+  padding:4px 0;
+}
+.address-suggestion{
+  display:flex;
+  flex-direction:column;
+  align-items:flex-start;
+  gap:2px;
+  width:100%;
+  padding:8px 12px;
+  border:0;
+  background:transparent;
+  font: inherit;
+  color:var(--ink);
+  text-align:left;
+  cursor:pointer;
+}
+.address-suggestion + .address-suggestion{ border-top:1px solid var(--line); }
+.address-suggestion:hover,
+.address-suggestion.is-active{
+  background:var(--brand-ghost);
+}
+.address-suggestion__primary{ font-weight:600; }
+.address-suggestion__meta{ font-size:12px; color:var(--muted); }
+
 .note {
   display: block;
 }

--- a/app/templates/clients.html
+++ b/app/templates/clients.html
@@ -74,6 +74,10 @@ const DEMOGRAPHIC_FIELDS = [
   { key: 'office_manager_email', label: 'Office Manager Email', type: 'email', linkPrefix: 'mailto:', linkLabel: 'Email' }
 ];
 const DEMOGRAPHIC_KEYS = new Set(DEMOGRAPHIC_FIELDS.map((f) => f.key));
+const ADDRESS_AUTOCOMPLETE_MIN_CHARS = 3;
+const ADDRESS_AUTOCOMPLETE_DEBOUNCE = 250;
+const ADDRESS_AUTOCOMPLETE_LIMIT = 8;
+let ADDRESS_AUTOCOMPLETE_DISABLED = false;
 
 function getApiToken(){ return window.localStorage.getItem('api_token') || ''; }
 function setApiToken(t){ if (t) window.localStorage.setItem('api_token', t); }
@@ -132,6 +136,278 @@ function attachQuickLink(def, input){
   input.addEventListener('input', update);
   link.addEventListener('click', (ev) => ev.stopPropagation());
   return link;
+}
+
+function formatAddressMeta(item){
+  if (!item) return '';
+  const cityState = [item.city, item.state].filter(Boolean).join(', ');
+  const parts = [];
+  if (cityState) parts.push(cityState);
+  if (item.postal_code) parts.push(item.postal_code);
+  let meta = parts.join(' ').trim();
+  if (item.entries && item.entries > 1){
+    meta = meta ? `${meta} (${item.entries} matches)` : `${item.entries} matches`;
+  }
+  if (!meta) meta = 'USPS verified';
+  return meta;
+}
+
+function setupAddressAutocomplete({ modal, container }){
+  if (ADDRESS_AUTOCOMPLETE_DISABLED) return null;
+  const line1Input = container.querySelector('input[data-attr-key="address_line1"]');
+  if (!line1Input) return null;
+
+  const line2Input = container.querySelector('input[data-attr-key="address_line2"]');
+  const cityInput = container.querySelector('input[data-attr-key="city"]');
+  const stateInput = container.querySelector('input[data-attr-key="state"]');
+  const postalInput = container.querySelector('input[data-attr-key="postal_code"]');
+  const host = line1Input.closest('label') || line1Input.parentElement;
+  if (!host) return null;
+
+  host.classList.add('address-autocomplete');
+  const suggestionBox = document.createElement('div');
+  suggestionBox.className = 'address-suggestions';
+  const listId = `address-suggestions-${Math.random().toString(36).slice(2)}`;
+  suggestionBox.id = listId;
+  suggestionBox.setAttribute('role', 'listbox');
+  suggestionBox.style.display = 'none';
+  host.appendChild(suggestionBox);
+
+  line1Input.setAttribute('autocomplete', 'off');
+  line1Input.setAttribute('role', 'combobox');
+  line1Input.setAttribute('aria-autocomplete', 'list');
+  line1Input.setAttribute('aria-haspopup', 'listbox');
+  line1Input.setAttribute('aria-expanded', 'false');
+  line1Input.setAttribute('aria-controls', listId);
+
+  let suggestions = [];
+  let highlightedIndex = -1;
+  let debounceTimer = null;
+  let activeController = null;
+  let destroyed = false;
+  let localDisabled = false;
+  let lastQuery = '';
+
+  function cleanup(){
+    if (destroyed) return;
+    destroyed = true;
+    if (debounceTimer) clearTimeout(debounceTimer);
+    if (activeController) activeController.abort();
+    line1Input.removeEventListener('input', onInput);
+    line1Input.removeEventListener('focus', onFocus);
+    line1Input.removeEventListener('keydown', onKeyDown);
+    line1Input.removeEventListener('blur', onBlur);
+    modal.removeEventListener('mousedown', onOutsidePointer);
+    suggestionBox.remove();
+    host.classList.remove('address-autocomplete');
+    line1Input.removeAttribute('aria-controls');
+    line1Input.removeAttribute('aria-expanded');
+    line1Input.removeAttribute('aria-autocomplete');
+    line1Input.removeAttribute('aria-haspopup');
+    line1Input.removeAttribute('role');
+  }
+
+  function hideSuggestions(){
+    suggestionBox.style.display = 'none';
+    suggestionBox.querySelectorAll('.address-suggestion').forEach((btn) => btn.classList.remove('is-active'));
+    highlightedIndex = -1;
+    line1Input.setAttribute('aria-expanded', 'false');
+  }
+
+  function highlightSuggestion(index){
+    const options = suggestionBox.querySelectorAll('.address-suggestion');
+    options.forEach((option, idx) => option.classList.toggle('is-active', idx === index));
+    highlightedIndex = index;
+  }
+
+  function renderSuggestions(){
+    suggestionBox.innerHTML = '';
+    if (!suggestions.length){
+      hideSuggestions();
+      return;
+    }
+    suggestions.forEach((item, index) => {
+      const option = document.createElement('button');
+      option.type = 'button';
+      option.className = 'address-suggestion';
+      option.setAttribute('role', 'option');
+      option.dataset.index = String(index);
+      const primary = document.createElement('div');
+      primary.className = 'address-suggestion__primary';
+      const streetParts = [];
+      if (item.street_line) streetParts.push(item.street_line);
+      if (item.secondary) streetParts.push(item.secondary);
+      primary.textContent = streetParts.join(' ').trim() || item.street_line || '';
+      option.appendChild(primary);
+      const meta = document.createElement('div');
+      meta.className = 'address-suggestion__meta';
+      meta.textContent = formatAddressMeta(item);
+      option.appendChild(meta);
+      option.addEventListener('mouseenter', () => highlightSuggestion(index));
+      option.addEventListener('mousedown', (ev) => ev.preventDefault());
+      option.addEventListener('click', () => applySuggestion(item));
+      suggestionBox.appendChild(option);
+    });
+    suggestionBox.style.display = 'block';
+    line1Input.setAttribute('aria-expanded', 'true');
+  }
+
+  function applySuggestion(item){
+    if (!item) return;
+    if (item.street_line) line1Input.value = item.street_line;
+    if (line2Input && item.secondary !== undefined && item.secondary !== null){
+      line2Input.value = item.secondary || '';
+    }
+    if (cityInput && item.city) cityInput.value = item.city;
+    if (stateInput && item.state) stateInput.value = item.state;
+    if (postalInput && item.postal_code) postalInput.value = item.postal_code;
+    hideSuggestions();
+    line1Input.dispatchEvent(new Event('change', { bubbles: true }));
+    verifySelection(item);
+  }
+
+  async function verifySelection(item){
+    if (ADDRESS_AUTOCOMPLETE_DISABLED || localDisabled) return;
+    const params = new URLSearchParams();
+    const street = (item && item.street_line) || line1Input.value.trim();
+    if (!street) return;
+    params.set('street', street);
+    const secondary = item.secondary || (line2Input ? line2Input.value.trim() : '');
+    if (secondary) params.set('secondary', secondary);
+    const cityValue = item.city || (cityInput ? cityInput.value.trim() : '');
+    if (cityValue) params.set('city', cityValue);
+    const stateValue = item.state || (stateInput ? stateInput.value.trim() : '');
+    if (stateValue) params.set('state', stateValue);
+    const zipValue = item.postal_code || (postalInput ? postalInput.value.trim() : '');
+    if (zipValue) params.set('zip', zipValue);
+    try {
+      const res = await fetch(`/api/v1/address/verify?${params.toString()}`, {
+        headers: apiHeaders(false),
+      });
+      if (res.status === 503){
+        ADDRESS_AUTOCOMPLETE_DISABLED = true;
+        localDisabled = true;
+        cleanup();
+        return;
+      }
+      if (!res.ok) return;
+      const data = await res.json();
+      const candidate = data.candidate || {};
+      if (candidate.delivery_line_1) line1Input.value = candidate.delivery_line_1;
+      if (line2Input && candidate.delivery_line_2) line2Input.value = candidate.delivery_line_2;
+      if (cityInput && candidate.city) cityInput.value = candidate.city;
+      if (stateInput && candidate.state) stateInput.value = candidate.state;
+      if (postalInput && candidate.postal_code) postalInput.value = candidate.postal_code;
+    } catch (err) {
+      console.warn('Address verification failed', err);
+    }
+  }
+
+  function onOutsidePointer(ev){
+    if (!host.contains(ev.target)) hideSuggestions();
+  }
+
+  function onInput(){
+    scheduleFetch();
+  }
+
+  function onFocus(){
+    if (suggestions.length){
+      renderSuggestions();
+    } else if (line1Input.value.trim().length >= ADDRESS_AUTOCOMPLETE_MIN_CHARS){
+      scheduleFetch();
+    }
+  }
+
+  function onBlur(){
+    window.setTimeout(() => {
+      if (!host.contains(document.activeElement)) hideSuggestions();
+    }, 150);
+  }
+
+  function onKeyDown(ev){
+    if (!suggestions.length || suggestionBox.style.display === 'none') return;
+    if (ev.key === 'ArrowDown'){
+      ev.preventDefault();
+      const nextIndex = (highlightedIndex + 1) % suggestions.length;
+      highlightSuggestion(nextIndex);
+    } else if (ev.key === 'ArrowUp'){
+      ev.preventDefault();
+      const nextIndex = highlightedIndex <= 0 ? suggestions.length - 1 : highlightedIndex - 1;
+      highlightSuggestion(nextIndex);
+    } else if (ev.key === 'Enter'){
+      if (highlightedIndex >= 0 && highlightedIndex < suggestions.length){
+        ev.preventDefault();
+        applySuggestion(suggestions[highlightedIndex]);
+      }
+    } else if (ev.key === 'Escape'){
+      hideSuggestions();
+    }
+  }
+
+  function scheduleFetch(){
+    if (ADDRESS_AUTOCOMPLETE_DISABLED || localDisabled) return;
+    if (debounceTimer) window.clearTimeout(debounceTimer);
+    debounceTimer = window.setTimeout(requestSuggestions, ADDRESS_AUTOCOMPLETE_DEBOUNCE);
+  }
+
+  async function requestSuggestions(){
+    if (ADDRESS_AUTOCOMPLETE_DISABLED || localDisabled) return;
+    const query = line1Input.value.trim();
+    if (!query || query.length < ADDRESS_AUTOCOMPLETE_MIN_CHARS){
+      suggestions = [];
+      hideSuggestions();
+      return;
+    }
+    if (query === lastQuery && suggestions.length){
+      renderSuggestions();
+      return;
+    }
+    lastQuery = query;
+    if (activeController) activeController.abort();
+    activeController = new AbortController();
+    const params = new URLSearchParams({ query, limit: String(ADDRESS_AUTOCOMPLETE_LIMIT) });
+    const cityValue = cityInput ? cityInput.value.trim() : '';
+    const stateValue = stateInput ? stateInput.value.trim() : '';
+    const zipValue = postalInput ? postalInput.value.trim() : '';
+    if (cityValue) params.set('city', cityValue);
+    if (stateValue) params.set('state', stateValue);
+    if (zipValue) params.set('zip', zipValue);
+    try {
+      const res = await fetch(`/api/v1/address/suggest?${params.toString()}`, {
+        headers: apiHeaders(false),
+        signal: activeController.signal,
+      });
+      if (res.status === 503){
+        ADDRESS_AUTOCOMPLETE_DISABLED = true;
+        localDisabled = true;
+        cleanup();
+        return;
+      }
+      if (!res.ok) throw new Error('Failed to fetch address suggestions');
+      const data = await res.json();
+      suggestions = Array.isArray(data.suggestions) ? data.suggestions : [];
+      if (!suggestions.length){
+        hideSuggestions();
+      } else {
+        renderSuggestions();
+      }
+    } catch (err) {
+      if (err.name === 'AbortError') return;
+      console.warn('Address autocomplete failed', err);
+      hideSuggestions();
+    } finally {
+      activeController = null;
+    }
+  }
+
+  line1Input.addEventListener('input', onInput);
+  line1Input.addEventListener('focus', onFocus);
+  line1Input.addEventListener('keydown', onKeyDown);
+  line1Input.addEventListener('blur', onBlur);
+  modal.addEventListener('mousedown', onOutsidePointer);
+
+  return cleanup;
 }
 
 function renderTable(data){
@@ -214,6 +490,18 @@ function openEditor(clientKey, entry, attributeKeys){
   const modal = document.getElementById('edit-modal');
   const fields = document.getElementById('edit-fields');
   const nameValue = entry.name || '';
+  const cleanupCallbacks = [];
+  const registerCleanup = (fn) => { if (typeof fn === 'function') cleanupCallbacks.push(fn); };
+  const runCleanup = () => {
+    while (cleanupCallbacks.length){
+      const fn = cleanupCallbacks.pop();
+      try { fn(); } catch (err) { console.warn('Cleanup failed', err); }
+    }
+  };
+  const closeModal = () => {
+    runCleanup();
+    modal.style.display = 'none';
+  };
   document.getElementById('edit-title').textContent = `Edit Client: ${clientKey}`;
   fields.innerHTML = '';
 
@@ -262,6 +550,9 @@ function openEditor(clientKey, entry, attributeKeys){
   }
 
   DEMOGRAPHIC_FIELDS.forEach(addDemographicRow);
+
+  const autocompleteCleanup = setupAddressAutocomplete({ modal, container: demographicsContainer });
+  if (autocompleteCleanup) registerCleanup(autocompleteCleanup);
 
   const attrHeading = document.createElement('h3');
   attrHeading.textContent = 'Custom Attributes';
@@ -318,7 +609,7 @@ function openEditor(clientKey, entry, attributeKeys){
     addAttrRow(key, entry[key]);
   });
 
-  document.getElementById('edit-close').onclick = () => { modal.style.display = 'none'; };
+  document.getElementById('edit-close').onclick = closeModal;
   modal.style.display = 'block';
 
   document.getElementById('edit-form').onsubmit = async (ev) => {
@@ -345,7 +636,7 @@ function openEditor(clientKey, entry, attributeKeys){
       body: JSON.stringify(payload)
     });
     if (r.ok){
-      modal.style.display = 'none';
+      closeModal();
       loadTable();
     } else {
       alert('Save failed');


### PR DESCRIPTION
## Summary
- add FastAPI endpoints that proxy SmartyStreets USPS autocomplete and verification services
- enhance the client edit modal with address suggestions, keyboard navigation, and verified field prefilling
- style the suggestion dropdown, add configuration and documentation, and include the httpx dependency

## Testing
- python -m compileall app *(fails: existing syntax error in app/crud/known_items.py)*

------
https://chatgpt.com/codex/tasks/task_e_68dff98a293483329b0d13fb0d74697c