### PR TITLE
Switch address autocomplete to Geoapify

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ stores data, and Docker Compose makes it easy to run everything locally.
   unique barcode, description, acquisition cost and sales price.
 * **Client list** – Load and display a list of clients from a JSON file
   (`client_table.json`).
-* **USPS-verified address autocomplete** – Client address fields can be
-  auto-completed with USPS-certified suggestions when SmartyStreets
-  credentials are provided.
+* **Geoapify address autocomplete** – Client address fields can be
+  auto-completed with Geoapify's geocoding suggestions when an API key
+  is configured.
 * **Responsive UI** – HTML pages served with Jinja2 templates and static
   resources provide a simple front‑end for managing tickets, hardware and
   clients.  Sessions and login keep your changes protected.
@@ -135,26 +135,27 @@ The application reads configuration from environment variables defined in
 | `TZ`                | Time zone for timestamps                    | `America/Chicago`    |
 | `SESSION_COOKIE_NAME` | Name of the session cookie                | `tt_session`         |
 | `SESSION_MAX_AGE`   | Session lifetime in seconds                 | `2592000` (30 days)  |
-| `SMARTY_AUTH_ID`    | SmartyStreets Auth ID for USPS address APIs | empty (disabled)     |
-| `SMARTY_AUTH_TOKEN` | SmartyStreets Auth Token                    | empty (disabled)     |
-| `SMARTY_AUTOCOMPLETE_URL` | Override for the autocomplete endpoint | Smarty default       |
-| `SMARTY_STREET_URL` | Override for the verification endpoint      | Smarty default       |
+| `GEOAPIFY_API_KEY`  | Geoapify API key for autocomplete & verification | empty (disabled) |
+| `GEOAPIFY_AUTOCOMPLETE_URL` | Override for the Geoapify autocomplete endpoint | Geoapify default |
+| `GEOAPIFY_GEOCODE_URL` | Override for the Geoapify geocode search endpoint | Geoapify default |
+| `GEOAPIFY_PLACE_URL` | Override for the Geoapify place lookup endpoint | Geoapify default |
 
 Refer to `app/core/config.py` and `docker-compose.yml` for the full list of
 environment variables and their defaults.
 
 ### Address autocomplete setup
 
-Address prefill in the client editor is powered by SmartyStreets' USPS-certified
-APIs. To enable it:
+Address prefill in the client editor is powered by Geoapify's Geocoding API. To
+enable it:
 
-1. Create a (free) SmartyStreets account and generate an **Auth ID** and
-   **Auth Token** for the US Autocomplete Pro and US Street APIs.
-2. Set the `SMARTY_AUTH_ID` and `SMARTY_AUTH_TOKEN` environment variables for
-   the application (for example in `.env` or your Docker Compose file).
+1. Create a (free) Geoapify account and generate an **API key** with Geocoding
+   API access.
+2. Set the `GEOAPIFY_API_KEY` environment variable for the application (for
+   example in `.env` or your Docker Compose file). Optional overrides for the
+   Geoapify endpoints are available via the other `GEOAPIFY_*` variables.
 3. Restart the application. When editing a client, typing into **Address Line 1**
-   will display USPS-verified suggestions. Selecting a suggestion automatically
-   fills the remaining city/state/ZIP fields after verification.
+   will display Geoapify-powered suggestions. Selecting a suggestion
+   automatically fills the remaining city/state/ZIP fields after verification.
 
 If the credentials are omitted, the UI silently falls back to manual entry.
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -32,16 +32,19 @@ class Settings:
     HOST = os.getenv("HOST", "0.0.0.0")
     PORT = int(os.getenv("PORT", "8089"))
 
-    # Address autocomplete (SmartyStreets USPS-verified services)
-    SMARTY_AUTH_ID = os.getenv("SMARTY_AUTH_ID", "")
-    SMARTY_AUTH_TOKEN = os.getenv("SMARTY_AUTH_TOKEN", "")
-    SMARTY_AUTOCOMPLETE_URL = os.getenv(
-        "SMARTY_AUTOCOMPLETE_URL",
-        "https://us-autocomplete-pro.api.smartystreets.com/lookup",
+    # Address autocomplete & geocoding (Geoapify)
+    GEOAPIFY_API_KEY = os.getenv("GEOAPIFY_API_KEY", "")
+    GEOAPIFY_AUTOCOMPLETE_URL = os.getenv(
+        "GEOAPIFY_AUTOCOMPLETE_URL",
+        "https://api.geoapify.com/v1/geocode/autocomplete",
     )
-    SMARTY_STREET_URL = os.getenv(
-        "SMARTY_STREET_URL",
-        "https://us-street.api.smartystreets.com/street-address",
+    GEOAPIFY_GEOCODE_URL = os.getenv(
+        "GEOAPIFY_GEOCODE_URL",
+        "https://api.geoapify.com/v1/geocode/search",
+    )
+    GEOAPIFY_PLACE_URL = os.getenv(
+        "GEOAPIFY_PLACE_URL",
+        "https://api.geoapify.com/v1/geocode/retrieve",
     )
 
 settings = Settings()

--- a/app/routers/address.py
+++ b/app/routers/address.py
@@ -45,6 +45,7 @@ async def verify_address(
     state: str | None = Query(default=None),
     postal_code: str | None = Query(default=None, alias="zip"),
     secondary: str | None = Query(default=None),
+    place_id: str | None = Query(default=None),
 ):
     try:
         candidate = await verify_postal_address(
@@ -53,6 +54,7 @@ async def verify_address(
             state=state,
             postal_code=postal_code,
             secondary=secondary,
+            place_id=place_id,
         )
     except AddressServiceNotConfigured as exc:  # pragma: no cover - configuration guard
         raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, str(exc)) from exc

--- a/app/services/address.py
+++ b/app/services/address.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import httpx
 
@@ -9,21 +9,110 @@ from ..core.config import settings
 
 logger = logging.getLogger(__name__)
 
+
 class AddressServiceNotConfigured(Exception):
     """Raised when address autocomplete credentials are missing."""
 
 
 def _ensure_configured() -> None:
-    if not settings.SMARTY_AUTH_ID or not settings.SMARTY_AUTH_TOKEN:
+    if not settings.GEOAPIFY_API_KEY:
         raise AddressServiceNotConfigured("Address autocomplete is not configured")
 
 
-def _format_zip(components: Dict[str, Any]) -> str:
-    zipcode = (components.get("zipcode") or "").strip()
-    plus4 = (components.get("plus4_code") or "").strip()
-    if zipcode and plus4:
-        return f"{zipcode}-{plus4}"
-    return zipcode
+def _extract_coordinates(
+    feature: Dict[str, Any], properties: Dict[str, Any]
+) -> Tuple[Optional[float], Optional[float]]:
+    lat = properties.get("lat")
+    lon = properties.get("lon")
+    if isinstance(lat, (int, float)) and isinstance(lon, (int, float)):
+        return float(lat), float(lon)
+
+    geometry = feature.get("geometry") or {}
+    coordinates = geometry.get("coordinates")
+    if isinstance(coordinates, (list, tuple)) and len(coordinates) >= 2:
+        lon_val, lat_val = coordinates[0], coordinates[1]
+        try:
+            return float(lat_val), float(lon_val)
+        except (TypeError, ValueError):
+            return None, None
+    return None, None
+
+
+def _map_suggestion(feature: Dict[str, Any]) -> Dict[str, Any]:
+    properties = feature.get("properties") or {}
+    lat, lon = _extract_coordinates(feature, properties)
+
+    suggestion = {
+        "street_line": properties.get("address_line1") or properties.get("street") or properties.get("formatted"),
+        "secondary": properties.get("address_line2") or "",
+        "city": properties.get("city"),
+        "state": properties.get("state_code") or properties.get("state"),
+        "postal_code": properties.get("postcode"),
+        "country": properties.get("country"),
+        "formatted": properties.get("formatted"),
+        "place_id": properties.get("place_id"),
+        "result_type": properties.get("result_type"),
+        "confidence": (properties.get("rank") or {}).get("confidence"),
+        "lat": lat,
+        "lon": lon,
+    }
+    return suggestion
+
+
+def _build_last_line(properties: Dict[str, Any]) -> str:
+    city = properties.get("city")
+    state = properties.get("state_code") or properties.get("state")
+    postal_code = properties.get("postcode")
+
+    parts: List[str] = []
+    if city and state:
+        parts.append(f"{city}, {state}")
+    else:
+        if city:
+            parts.append(str(city))
+        if state:
+            parts.append(str(state))
+    if postal_code:
+        parts.append(str(postal_code))
+
+    if parts:
+        return " ".join(parts)
+    return properties.get("formatted") or ""
+
+
+def _map_verified_address(feature: Dict[str, Any]) -> Dict[str, Any]:
+    properties = feature.get("properties") or {}
+    lat, lon = _extract_coordinates(feature, properties)
+
+    verified = {
+        "delivery_line_1": properties.get("address_line1")
+        or properties.get("street")
+        or properties.get("formatted"),
+        "delivery_line_2": properties.get("address_line2") or "",
+        "last_line": _build_last_line(properties),
+        "city": properties.get("city"),
+        "state": properties.get("state_code") or properties.get("state"),
+        "postal_code": properties.get("postcode"),
+        "country": properties.get("country"),
+        "county": properties.get("county"),
+        "dpv_match_code": None,
+        "footnotes": None,
+        "latitude": lat,
+        "longitude": lon,
+        "place_id": properties.get("place_id"),
+        "confidence": (properties.get("rank") or {}).get("confidence"),
+    }
+    return verified
+
+
+def _raise_for_status(response: httpx.Response, context: str) -> None:
+    if response.status_code in {401, 403}:
+        logger.warning("Geoapify authentication failed for %s", context)
+    elif response.status_code >= 500:
+        logger.error("Geoapify service error %s during %s", response.status_code, context)
+    elif response.status_code >= 400:
+        logger.error("Geoapify request error %s during %s", response.status_code, context)
+    response.raise_for_status()
 
 
 async def fetch_autocomplete_suggestions(
@@ -34,7 +123,7 @@ async def fetch_autocomplete_suggestions(
     postal_code: Optional[str] = None,
     max_results: int = 10,
 ) -> List[Dict[str, Any]]:
-    """Return USPS-verified address suggestions via SmartyStreets Autocomplete Pro."""
+    """Return address suggestions using the Geoapify autocomplete endpoint."""
 
     _ensure_configured()
 
@@ -42,44 +131,36 @@ async def fetch_autocomplete_suggestions(
         return []
 
     params: Dict[str, Any] = {
-        "search": search.strip(),
-        "auth-id": settings.SMARTY_AUTH_ID,
-        "auth-token": settings.SMARTY_AUTH_TOKEN,
-        "source": "all",
-        "max_results": max_results,
+        "text": search.strip(),
+        "apiKey": settings.GEOAPIFY_API_KEY,
+        "limit": max_results,
+        "type": "street",
     }
 
-    if city:
-        params["include_only_cities"] = city
-    if state:
-        params["include_only_states"] = state
-    if postal_code:
-        params["include_only_zip_codes"] = postal_code
+    filters: List[str] = []
+    if city and city.strip():
+        filters.append(f"city:{city.strip()}")
+    if state and state.strip():
+        cleaned_state = state.strip()
+        if len(cleaned_state) == 2:
+            filters.append(f"statecode:{cleaned_state}")
+        else:
+            filters.append(f"state:{cleaned_state}")
+    if postal_code and postal_code.strip():
+        filters.append(f"postcode:{postal_code.strip()}")
+    if filters:
+        params["filter"] = "|".join(filters)
 
     timeout = httpx.Timeout(6.0)
     async with httpx.AsyncClient(timeout=timeout) as client:
-        response = await client.get(settings.SMARTY_AUTOCOMPLETE_URL, params=params)
+        response = await client.get(settings.GEOAPIFY_AUTOCOMPLETE_URL, params=params)
 
-    if response.status_code == 401:
-        logger.warning("SmartyStreets authentication failed for address autocomplete")
-        raise httpx.HTTPStatusError("Unauthorized", request=response.request, response=response)
-    if response.status_code >= 500:
-        logger.error("SmartyStreets service error %s", response.status_code)
-        raise httpx.HTTPStatusError("Service unavailable", request=response.request, response=response)
+    _raise_for_status(response, "address autocomplete")
 
     data = response.json()
     suggestions: List[Dict[str, Any]] = []
-    for item in data.get("suggestions", []):
-        suggestion = {
-            "street_line": item.get("street_line") or item.get("primary_line"),
-            "secondary": item.get("secondary") or "",
-            "city": item.get("city"),
-            "state": item.get("state"),
-            "postal_code": item.get("zipcode"),
-            "entries": item.get("entries"),
-            "source": item.get("source"),
-        }
-        suggestions.append(suggestion)
+    for feature in data.get("features", []):
+        suggestions.append(_map_suggestion(feature))
 
     return suggestions
 
@@ -91,57 +172,50 @@ async def verify_postal_address(
     state: Optional[str] = None,
     postal_code: Optional[str] = None,
     secondary: Optional[str] = None,
+    place_id: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
-    """Verify a selected address via SmartyStreets US Street API."""
+    """Verify a selected address via Geoapify geocoding APIs."""
 
     _ensure_configured()
 
-    payload: List[Dict[str, Any]] = [
-        {
-            "street": street_line,
-            "city": city,
-            "state": state,
-            "zipcode": postal_code,
-            "secondary": secondary or None,
-            "candidates": 1,
-        }
-    ]
-
-    timeout = httpx.Timeout(6.0)
-    params = {
-        "auth-id": settings.SMARTY_AUTH_ID,
-        "auth-token": settings.SMARTY_AUTH_TOKEN,
-    }
-    async with httpx.AsyncClient(timeout=timeout) as client:
-        response = await client.post(
-            settings.SMARTY_STREET_URL,
-            params=params,
-            json=payload,
-        )
-
-    if response.status_code == 401:
-        logger.warning("SmartyStreets authentication failed for address verification")
-        raise httpx.HTTPStatusError("Unauthorized", request=response.request, response=response)
-    if response.status_code >= 500:
-        logger.error("SmartyStreets street API error %s", response.status_code)
-        raise httpx.HTTPStatusError("Service unavailable", request=response.request, response=response)
-
-    candidates = response.json()
-    if not candidates:
+    if not street_line or not street_line.strip():
         return None
 
-    candidate = candidates[0]
-    components = candidate.get("components") or {}
-
-    verified = {
-        "delivery_line_1": candidate.get("delivery_line_1"),
-        "delivery_line_2": candidate.get("delivery_line_2") or "",
-        "last_line": candidate.get("last_line"),
-        "city": components.get("city_name"),
-        "state": components.get("state_abbreviation"),
-        "postal_code": _format_zip(components),
-        "county": candidate.get("metadata", {}).get("county_name"),
-        "dpv_match_code": candidate.get("analysis", {}).get("dpv_match_code"),
-        "footnotes": candidate.get("analysis", {}).get("footnotes"),
+    timeout = httpx.Timeout(6.0)
+    base_params: Dict[str, Any] = {
+        "apiKey": settings.GEOAPIFY_API_KEY,
+        "limit": 1,
     }
-    return verified
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        if place_id:
+            params = {**base_params, "place_id": place_id}
+            response = await client.get(settings.GEOAPIFY_PLACE_URL, params=params)
+        else:
+            street_parts = [street_line.strip()]
+            if secondary and secondary.strip():
+                street_parts.append(secondary.strip())
+
+            locality_parts = []
+            if city and city.strip():
+                locality_parts.append(city.strip())
+            if state and state.strip():
+                locality_parts.append(state.strip())
+            if postal_code and postal_code.strip():
+                locality_parts.append(postal_code.strip())
+
+            text_query = ", ".join(
+                part for part in [" ".join(street_parts).strip(), " ".join(locality_parts).strip()]
+                if part
+            )
+            params = {**base_params, "text": text_query or street_line.strip()}
+            response = await client.get(settings.GEOAPIFY_GEOCODE_URL, params=params)
+
+    _raise_for_status(response, "address verification")
+
+    data = response.json()
+    features = data.get("features") or []
+    if not features:
+        return None
+
+    return _map_verified_address(features[0])

--- a/app/templates/clients.html
+++ b/app/templates/clients.html
@@ -144,12 +144,10 @@ function formatAddressMeta(item){
   const parts = [];
   if (cityState) parts.push(cityState);
   if (item.postal_code) parts.push(item.postal_code);
-  let meta = parts.join(' ').trim();
-  if (item.entries && item.entries > 1){
-    meta = meta ? `${meta} (${item.entries} matches)` : `${item.entries} matches`;
-  }
-  if (!meta) meta = 'USPS verified';
-  return meta;
+  if (item.country) parts.push(item.country);
+  if (!parts.length && item.formatted) parts.push(item.formatted);
+  if (!parts.length) parts.push('Geoapify');
+  return parts.join(' · ');
 }
 
 function setupAddressAutocomplete({ modal, container }){
@@ -280,6 +278,7 @@ function setupAddressAutocomplete({ modal, container }){
     if (stateValue) params.set('state', stateValue);
     const zipValue = item.postal_code || (postalInput ? postalInput.value.trim() : '');
     if (zipValue) params.set('zip', zipValue);
+    if (item.place_id) params.set('place_id', item.place_id);
     try {
       const res = await fetch(`/api/v1/address/verify?${params.toString()}`, {
         headers: apiHeaders(false),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,9 @@ services:
       SESSION_COOKIE_NAME: 'tt_session'
       SESSION_MAX_AGE: '2592000'  # 30 days in seconds
 
+      # --- Geoapify address autocomplete ---
+      GEOAPIFY_API_KEY: ${GEOAPIFY_API_KEY:-}
+
     volumes:
       - ./data:/data
     ports:


### PR DESCRIPTION
## Summary
- replace the SmartyStreets configuration with Geoapify environment settings and endpoints
- rebuild the address service to call Geoapify autocomplete and verification APIs and expose the optional place_id on the verify route
- surface Geoapify-specific suggestion metadata in the client editor and update docs and compose defaults

## Testing
- `python -m compileall app/core/config.py app/services/address.py app/routers/address.py`


------
https://chatgpt.com/codex/tasks/task_e_68e0259c49248332965a594a25490d8f