### PR TITLE
Add legacy getUserMedia polyfill for barcode scanner

### DIFF
--- a/app/templates/hardware.html
+++ b/app/templates/hardware.html
@@ -147,8 +147,29 @@
       }
     }
 
+    function ensureGetUserMedia(){
+      if (!('mediaDevices' in navigator)){
+        navigator.mediaDevices = {};
+      }
+      if (typeof navigator.mediaDevices.getUserMedia === 'function'){
+        return true;
+      }
+
+      const legacy = navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia || navigator.msGetUserMedia;
+      if (legacy){
+        navigator.mediaDevices.getUserMedia = function(constraints){
+          return new Promise(function(resolve, reject){
+            legacy.call(navigator, constraints, resolve, reject);
+          });
+        };
+        return true;
+      }
+
+      return false;
+    }
+
     function hasCameraSupport(){
-      return !!(navigator.mediaDevices && typeof navigator.mediaDevices.getUserMedia === 'function');
+      return ensureGetUserMedia();
     }
 
     async function ensureZXing(){


### PR DESCRIPTION
## Summary
- add a helper that ensures `navigator.mediaDevices.getUserMedia` is available before enabling the barcode scanner
- reuse the helper when checking for camera support so iOS and legacy browsers can request camera access

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5222ec42c83329793ef9a47dc766b