### PR TITLE
Sort completed tickets to bottom and update styling

### DIFF
--- a/app/templates/_rows.html
+++ b/app/templates/_rows.html
@@ -1,5 +1,5 @@
 {% for r in rows %}
-<tr class="row {{ 'is-done' if r.completed else '' }}" data-id="{{ r.id }}">
+<tr class="row {{ 'is-done' if r.completed else 'is-open' }}" data-id="{{ r.id }}">
   <td class="mono" data-label="ID">
     <a href="#" class="js-edit-ticket" data-id="{{ r.id }}" style="color:inherit; text-decoration:none;">{{ r.id }}</a>
   </td>

--- a/app/templates/tickets.html
+++ b/app/templates/tickets.html
@@ -54,6 +54,46 @@
 
     }
 
+    .tickets-table tr.row.is-open td {
+
+      background: rgba(45, 108, 223, 0.12);
+
+      color: #0f172a;
+
+      font-weight: 600;
+
+      transition: background-color 160ms ease-in-out, color 160ms ease-in-out;
+
+    }
+
+    .tickets-table tr.row.is-open:hover td {
+
+      background: rgba(45, 108, 223, 0.18);
+
+    }
+
+    .tickets-table tr.row.is-done td {
+
+      background: #f8fafc;
+
+      color: #94a3b8;
+
+      transition: background-color 160ms ease-in-out, color 160ms ease-in-out;
+
+    }
+
+    .tickets-table tr.row.is-done:hover td {
+
+      background: #f1f5f9;
+
+    }
+
+    .tickets-table tr.row.is-done a {
+
+      color: inherit;
+
+    }
+
     @media (min-width: 2560px) {
 
       .tickets-table .note { max-width: 480px; }
@@ -391,6 +431,40 @@
 
     }
 
+    function sortTicketRows(){
+
+      const rows = Array.from(ticketRows.querySelectorAll('tr.row'));
+
+      if (!rows.length) return;
+
+      const open = [];
+
+      const done = [];
+
+      rows.forEach(row => {
+
+        if (row.classList.contains('is-done')){
+
+          done.push(row);
+
+        } else {
+
+          open.push(row);
+
+        }
+
+      });
+
+      const frag = document.createDocumentFragment();
+
+      open.forEach(row => frag.appendChild(row));
+
+      done.forEach(row => frag.appendChild(row));
+
+      ticketRows.appendChild(frag);
+
+    }
+
     async function refreshTable(){
 
       const res = await safeFetch('/ui/ticket_table', { headers: { 'X-Requested-With': 'fetch' } }, false);
@@ -398,6 +472,8 @@
       if (res.ok){
 
         ticketRows.innerHTML = await res.text();
+
+        sortTicketRows();
 
         applyNotePreviews();
 
@@ -981,6 +1057,8 @@
       resizeTimer = setTimeout(applyNotePreviews, 150);
 
     });
+
+    sortTicketRows();
 
     applyNotePreviews();
 


### PR DESCRIPTION
## Summary
- add an `is-open` class to active ticket rows so they can be styled distinctly
- introduce client-side sorting that keeps completed tickets at the bottom of the table
- refresh the ticket list styling to brighten open rows and mute completed ones for contrast

## Testing
- Manual verification of ticket sorting and styling in the browser

------
https://chatgpt.com/codex/tasks/task_e_68e53938d9848332a7ec8c3018590e6d