### PR TITLE
Add sent status workflow and filter toggle to tickets UI

### DIFF
--- a/app/crud/tickets.py
+++ b/app/crud/tickets.py
@@ -97,6 +97,7 @@ def create_entry(db: Session, payload: dict) -> Ticket:
         end_iso=payload.get("end_iso"),
         note=payload.get("note"),
         completed=0,
+        sent=payload.get("sent", 0) or 0,
         invoice_number=payload.get("invoice_number"),
         created_at=payload.get("created_at") or datetime.utcnow().isoformat(timespec="seconds") + "Z",
         entry_type=payload.get("entry_type", "time"),

--- a/app/db/migrate.py
+++ b/app/db/migrate.py
@@ -76,6 +76,7 @@ def run_migrations(engine: Engine) -> None:
         "hardware_id": "INTEGER",
         "hardware_description": "TEXT",
         "hardware_sales_price": "TEXT",
+        "sent": "INTEGER DEFAULT 0 NOT NULL",
     }
 
     # Tickets table incremental columns

--- a/app/models/ticket.py
+++ b/app/models/ticket.py
@@ -17,6 +17,7 @@ class Ticket(Base):
     rounded_hours = Column(Text, nullable=False)
     note = Column(Text, nullable=True)
     completed = Column(Integer, nullable=False)
+    sent = Column(Integer, nullable=False, default=0)
     invoice_number = Column(Text, nullable=True)
     created_at = Column(Text, nullable=False)
     minutes = Column(Integer, nullable=False, default=0)

--- a/app/schemas/ticket.py
+++ b/app/schemas/ticket.py
@@ -16,6 +16,7 @@ class EntryCreate(EntryBase):
     start_iso: str
     end_iso: Optional[str] = None
     invoice_number: Optional[str] = None
+    sent: Optional[int] = 0
 
 
 class EntryUpdate(BaseModel):
@@ -25,6 +26,7 @@ class EntryUpdate(BaseModel):
     end_iso: Optional[str] = None
     note: Optional[str] = None
     completed: Optional[int] = None
+    sent: Optional[int] = None
     invoice_number: Optional[str] = None
     entry_type: Optional[str] = Field(default=None, pattern="^(time|hardware)$")
     hardware_id: Optional[int] = None
@@ -42,6 +44,7 @@ class EntryOut(BaseModel):
     rounded_hours: str
     note: Optional[str]
     completed: int
+    sent: int
     invoice_number: Optional[str]
     created_at: str
     minutes: int

--- a/app/static/app.css
+++ b/app/static/app.css
@@ -41,6 +41,32 @@ body.dashboard{ background:#f4f6fb; color:var(--ink); font: 14px/1.45 system-ui,
   gap:12px;
   margin-top:16px;
 }
+.app-header .nav-controls{
+  display:flex;
+  flex-wrap:wrap;
+  gap:12px;
+  margin-top:16px;
+  align-items:center;
+}
+.app-header .nav-controls .links{
+  margin-top:0;
+  flex:1 1 auto;
+}
+.app-header .show-sent-toggle{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  flex:0 0 auto;
+  border-color:var(--line);
+  background:#fff;
+  color:var(--ink);
+}
+.app-header .show-sent-toggle span{
+  white-space:nowrap;
+}
+.app-header .show-sent-toggle input{
+  accent-color:var(--brand);
+}
 .app-header .links .pill{
   border-color:var(--line);
   background:#fff;
@@ -151,6 +177,9 @@ details[open] .note-toggle{ transform:rotate(90deg); }
 /* Row state */
 .row.is-done td{ opacity:.88; }
 .row.is-open td{ background:#fff; }
+body.hide-sent #ticket-rows tr[data-sent="1"]{
+  display:none;
+}
 
 /* Hint */
 .table-hint{ color:var(--muted); text-align:center; font-size:12px; margin:8px 0 0; }
@@ -493,8 +522,24 @@ details[open] .note-toggle {
   height:36px; padding:0 10px; border:1px solid var(--line); border-radius:10px; background:#fff; color:#0b1220;
 }
 
-/* === additions: align Open/Done pill and Delete button horizontally in action cell === */
-.td-action { display:flex; gap:10px; align-items:center; justify-content:center; }
+/* Status + action cell layout */
+.td-action {
+  display:flex;
+  flex-wrap:wrap;
+  gap:10px;
+  align-items:center;
+  justify-content:flex-start;
+}
+.td-action .status-group{
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+  flex:1 1 220px;
+}
+.td-action .status-pill{
+  flex:1 1 140px;
+  justify-content:center;
+}
 .td-action form { display:inline-flex; margin:0; }
 .td-action .btn-danger { height:30px; width:30px; padding:0; display:inline-flex; align-items:center; justify-content:center; }
 
@@ -513,6 +558,9 @@ details[open] .note-toggle {
   :root{ --container: min(960px, 94vw); }
   .app-header .container{ padding-block:20px; }
   .app-header .actions{ margin-top:12px; }
+  .app-header .nav-controls{ flex-direction:column; align-items:stretch; }
+  .app-header .nav-controls .links{ width:100%; }
+  .app-header .show-sent-toggle{ width:100%; justify-content:center; }
   .filters-grid{ grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); }
   .field,
   .field--wide,
@@ -570,6 +618,13 @@ details[open] .note-toggle {
     justify-content:flex-start;
     flex-wrap:wrap;
     gap:10px;
+  }
+  .td-action .status-group{
+    width:100%;
+  }
+  .td-action .status-pill{
+    flex:1 1 auto;
+    width:100%;
   }
   .td-action .pill{ width:100%; justify-content:center; }
   .td-action .btn-icon{ flex:0 0 auto; }

--- a/app/templates/_row.html
+++ b/app/templates/_row.html
@@ -29,7 +29,7 @@
   </td>
 
   <td class="action">
-    <button class="pill {{ 'ok' if r.completed else '' }} js-toggle" title="Toggle done">{{ 'Done' if r.completed else 'Open' }}</button>
+    <button class="pill {{ 'ok' if r.completed else '' }} js-toggle" title="Toggle Added to QB">{{ 'Added to QB' if r.completed else 'Open' }}</button>
     <button class="icon danger js-del" title="Delete">✕</button>
   </td>
 </tr>

--- a/app/templates/_rows.html
+++ b/app/templates/_rows.html
@@ -1,5 +1,5 @@
 {% for r in rows %}
-<tr class="row {{ 'is-done' if r.completed else 'is-open' }}" data-id="{{ r.id }}">
+<tr class="row {{ 'is-done' if r.completed else 'is-open' }} {{ 'is-sent' if r.sent else 'is-unsent' }}" data-id="{{ r.id }}" data-sent="{{ 1 if r.sent else 0 }}">
   <td class="mono" data-label="ID">
     <a href="#" class="js-edit-ticket" data-id="{{ r.id }}" style="color:inherit; text-decoration:none;">{{ r.id }}</a>
   </td>
@@ -24,12 +24,18 @@
   <td class="mono invoice" data-label="Invoice">
     <input type="text" class="invoice-input" data-id="{{ r.id }}" value="{{ r.invoice_number or '' }}" placeholder="Invoice #" />
   </td>
-  <td class="td-action" data-label="Actions">
-    <label class="pill pill-checkbox {{ 'ok' if r.completed else '' }}">
-      <input type="checkbox" class="js-complete-checkbox" data-id="{{ r.id }}" {{ 'checked' if r.completed }} />
-      <span>{{ 'Done' if r.completed else 'Open' }}</span>
-    </label>
-    <button class="pill js-toggle-status {{ 'ok' if r.completed else '' }}" type="button" data-id="{{ r.id }}" data-completed="{{ 1 if r.completed else 0 }}">{{ 'Done' if r.completed else 'Open' }}</button>
+  <td class="td-action" data-label="Status / Actions">
+    <div class="status-group">
+      <label class="pill pill-checkbox status-pill {{ 'ok' if r.completed else '' }}">
+        <input type="checkbox" class="js-complete-checkbox" data-id="{{ r.id }}" {{ 'checked' if r.completed }} />
+        <span>{{ 'Added to QB' if r.completed else 'Open' }}</span>
+      </label>
+      <label class="pill pill-checkbox status-pill {{ 'ok' if r.sent else '' }}">
+        <input type="checkbox" class="js-sent-checkbox" data-id="{{ r.id }}" {{ 'checked' if r.sent }} />
+        <span>{{ 'Sent' if r.sent else 'Not Sent' }}</span>
+      </label>
+    </div>
+    <button class="pill js-toggle-status {{ 'ok' if r.completed else '' }}" type="button" data-id="{{ r.id }}" data-completed="{{ 1 if r.completed else 0 }}">{{ 'Added to QB' if r.completed else 'Open' }}</button>
     <button class="btn btn-danger btn-icon js-delete-ticket" type="button" data-id="{{ r.id }}" aria-label="Delete ticket {{ r.id }}">
       <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
         <path fill="currentColor" d="M9 3a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1h5v1h-2v16a2 2 0 0 1-2.1 2H8.1A2 2 0 0 1 6 20V4H4V3h5zm1 0h4v1h-4V3zM8 9h2v10H8V9zm4 0h2v10h-2V9zm4 0h2v10h-2V9z"/>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -438,7 +438,7 @@
                 <strong>{{ ticket.client }}</strong>
                 <span class="meta">Ticket #{{ ticket.id }} · {{ ticket.entry_type }}</span>
               </div>
-              <span class="badge">{{ 'Done' if ticket.completed else 'Open' }}</span>
+              <span class="badge">{{ 'Added to QB' if ticket.completed else 'Open' }}</span>
               <div style="grid-column: 1 / span 2; color: var(--txt-muted); font-size:0.9rem;">
                 {{ ticket.note or ticket.hardware_description or 'No details captured yet.' }}
               </div>

--- a/app/templates/tickets.html
+++ b/app/templates/tickets.html
@@ -104,7 +104,7 @@
 
 </head>
 
-<body class="dashboard">
+<body class="dashboard hide-sent">
 
   <header class="app-header">
 
@@ -118,12 +118,18 @@
 
       </div>
 
-      <nav class="links">
-        <a href="/" class="pill">Dashboard</a>
-        <a href="/tickets" class="pill active" aria-current="page">Tickets</a>
-        <a href="/hardware" class="pill">Hardware</a>
-        <a href="/clients" class="pill">Clients</a>
-      </nav>
+      <div class="nav-controls">
+        <nav class="links">
+          <a href="/" class="pill">Dashboard</a>
+          <a href="/tickets" class="pill active" aria-current="page">Tickets</a>
+          <a href="/hardware" class="pill">Hardware</a>
+          <a href="/clients" class="pill">Clients</a>
+        </nav>
+        <label class="pill pill-checkbox show-sent-toggle">
+          <input type="checkbox" id="show-sent-toggle" />
+          <span>Show Sent Items</span>
+        </label>
+      </div>
 
     </div>
 
@@ -163,7 +169,7 @@
 
               <th class="mono">Invoice</th>
 
-              <th class="th-action">Actions</th>
+              <th class="th-action">Status / Actions</th>
 
             </tr>
 
@@ -257,13 +263,25 @@
 
           <label>Invoice #<input name="invoice_number" class="mono" /></label>
 
-          <label>Completed
+          <label>Added to QB
 
             <select name="completed">
 
               <option value="0">Open</option>
 
-              <option value="1">Done</option>
+              <option value="1">Added to QB</option>
+
+            </select>
+
+          </label>
+
+          <label>Sent
+
+            <select name="sent">
+
+              <option value="0">Not Sent</option>
+
+              <option value="1">Sent</option>
 
             </select>
 
@@ -287,7 +305,7 @@
 
           <button class="btn" type="submit">Save</button>
 
-          <button class="btn" type="button" id="ticket-mark-done">Toggle Done</button>
+          <button class="btn" type="button" id="ticket-mark-done">Toggle Added to QB</button>
 
         </div>
 
@@ -349,6 +367,8 @@
 
     const ticketRows = document.getElementById('ticket-rows');
 
+    const body = document.body;
+
     const modal = document.getElementById('ticket-modal');
 
     const title = document.getElementById('ticket-modal-title');
@@ -376,6 +396,42 @@
     const clientForm = document.getElementById('client-form');
 
     const clientFields = document.getElementById('client-fields');
+
+    const showSentToggle = document.getElementById('show-sent-toggle');
+
+    const SENT_FILTER_KEY = 'tickets_show_sent';
+
+    if (showSentToggle){
+
+      const storedPreference = window.localStorage.getItem(SENT_FILTER_KEY);
+
+      if (storedPreference === '1'){
+
+        showSentToggle.checked = true;
+
+        body.classList.remove('hide-sent');
+
+      }
+
+      showSentToggle.addEventListener('change', ()=>{
+
+        if (showSentToggle.checked){
+
+          body.classList.remove('hide-sent');
+
+          window.localStorage.setItem(SENT_FILTER_KEY, '1');
+
+        } else {
+
+          body.classList.add('hide-sent');
+
+          window.localStorage.setItem(SENT_FILTER_KEY, '0');
+
+        }
+
+      });
+
+    }
 
 
 
@@ -559,6 +615,12 @@
 
       elements.completed.value = String(data.completed || 0);
 
+      if (elements.sent){
+
+        elements.sent.value = String(data.sent ?? 0);
+
+      }
+
       elements.elapsed_minutes.value = data.elapsed_minutes ?? '';
 
       elements.rounded_minutes.value = data.rounded_minutes ?? '';
@@ -630,6 +692,8 @@
           end_iso: '',
 
           completed: 0,
+
+          sent: 0,
 
           created_at: now.toISOString(),
 
@@ -807,7 +871,9 @@
 
         hardware_barcode: elements.hardware_barcode.value.trim() || null,
 
-        completed: Number(elements.completed.value)
+        completed: Number(elements.completed.value),
+
+        sent: elements.sent ? Number(elements.sent.value) : 0
 
       };
 
@@ -875,7 +941,7 @@
 
       } else {
 
-        window.alert('Toggle failed');
+        window.alert('Toggle Added to QB failed');
 
       }
 
@@ -1018,7 +1084,33 @@
 
         });
 
-        if (!res.ok) window.alert('Status update failed');
+        if (!res.ok) window.alert('Added to QB update failed');
+
+        await refreshTable();
+
+        return;
+
+      }
+
+      const sentCheckbox = e.target.closest('.js-sent-checkbox');
+
+      if (sentCheckbox){
+
+        const id = sentCheckbox.dataset.id;
+
+        const next = sentCheckbox.checked ? 1 : 0;
+
+        const res = await safeFetch(`/api/v1/tickets/${id}`, {
+
+          method: 'PATCH',
+
+          headers: apiHeaders(true),
+
+          body: JSON.stringify({ sent: next })
+
+        });
+
+        if (!res.ok) window.alert('Sent status update failed');
 
         await refreshTable();
 


### PR DESCRIPTION
## Summary
- add a `sent` flag to tickets, wire it through the ORM models, schema, and migrations
- expose the sent status in the tickets table with a new toggle, rename "Done" to "Added to QB", and provide a Show Sent Items filter
- update dashboard badges and styling so sent rows are hidden by default and responsive layouts handle the new controls

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e53ccfeb748332be19f5e81e6e1599