### PR TITLE
Refine note preview button styling

### DIFF
--- a/app/templates/tickets.html
+++ b/app/templates/tickets.html
@@ -26,9 +26,17 @@
 
       text-align: left;
 
+      appearance: none;
+
+      -webkit-appearance: none;
+
       background: none;
 
+      background-color: transparent;
+
       border: none;
+
+      border-radius: 0;
 
       padding: 0;
 
@@ -43,6 +51,14 @@
       overflow: hidden;
 
       text-overflow: ellipsis;
+
+    }
+
+    .note-preview-btn:focus-visible {
+
+      outline: 2px solid var(--brand);
+
+      outline-offset: 2px;
 
     }
 


### PR DESCRIPTION
## Summary
- remove native styling from the ticket note preview button so it inherits the table row background
- add a focus-visible outline to preserve keyboard focus visibility after the appearance reset

## Testing
- DATA_DIR=/workspace/time-tracker4-refactored/data uvicorn app:app --host 0.0.0.0 --port 8089 (manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68e558400e4c8332959c0873eda88ba7