### PR TITLE
Fix note preview button background to match row tint

### DIFF
--- a/app/templates/tickets.html
+++ b/app/templates/tickets.html
@@ -30,9 +30,7 @@
 
       -webkit-appearance: none;
 
-      background: none;
-
-      background-color: transparent;
+      background: inherit;
 
       border: none;
 


### PR DESCRIPTION
## Summary
- ensure the note preview toggle button inherits its row background color so collapsed notes match row tints

## Testing
- DATA_DIR=/workspace/time-tracker4-refactored/data uvicorn app:app --host 0.0.0.0 --port 8089

------
https://chatgpt.com/codex/tasks/task_e_68e55b9421488332be99c62700fc261c