### PR TITLE
Improve note column layout

### DIFF
--- a/app/static/app.css
+++ b/app/static/app.css
@@ -121,6 +121,7 @@ input[type="text"], input[type="date"], select{
 }
 .th-action{ text-align:center; }
 .table tbody td{ padding:12px; border-bottom:1px solid var(--line); vertical-align:top; }
+.table tbody td.note{ padding:0; }
 .table tbody tr:hover{ background:#fafbff; }
 .table .mono{ font-family:var(--mono); }
 
@@ -137,14 +138,29 @@ col.col-note    { width:auto; } /* remaining width goes to Notes */
 
 /* Notes (collapsible) */
 .note-cell{ --clamp: 2; }
+.note-cell,
+.note-cell.collapsed{
+  display:flex;
+  align-items:center;
+  gap:12px;
+  padding:12px;
+  height:100%;
+  width:100%;
+}
 .note{ display:block; }
 .note details > summary{
   list-style:none; display:flex; align-items:flex-start; gap:8px; cursor:pointer; user-select:none;
 }
 .note details > summary::-webkit-details-marker{ display:none; }
 .note-toggle{
-  width:20px; height:20px; border-radius:6px; border:1px solid var(--line);
-  background:#fff; position:relative; transform:rotate(0deg);
+  width:20px;
+  height:20px;
+  border-radius:6px;
+  border:1px solid var(--line);
+  background:#fff;
+  position:relative;
+  transform:rotate(0deg);
+  flex:0 0 20px;
 }
 .note-toggle::before{
   content:""; position:absolute; inset: 6px 4px 4px 4px;
@@ -154,8 +170,14 @@ col.col-note    { width:auto; } /* remaining width goes to Notes */
 details[open] .note-toggle{ transform:rotate(90deg); }
 
 .note-preview{
-  display:-webkit-box; -webkit-box-orient:vertical; -webkit-line-clamp: var(--clamp);
-  overflow:hidden; color:#111827;
+  display:-webkit-box;
+  -webkit-box-orient:vertical;
+  -webkit-line-clamp: var(--clamp);
+  overflow:hidden;
+  color:#111827;
+  flex:1 1 auto;
+  min-width:0;
+  align-self:stretch;
 }
 .note-full{ padding:6px 0 0 28px; color:#111827; }
 
@@ -435,39 +457,56 @@ body.hide-sent #ticket-rows tr[data-sent="1"]{
 .address-suggestion__primary{ font-weight:600; }
 .address-suggestion__meta{ font-size:12px; color:var(--muted); }
 
+
 .note {
-  display: block;
+  display:block;
 }
 
-.note details > summary {
-  cursor: pointer;
-  font-weight: bold;
+.note details > summary{
+  cursor:pointer;
+  font-weight:bold;
 }
 
-.note details > summary::-webkit-details-marker {
-  display: none; /* Hide default marker */
+.note details > summary::-webkit-details-marker{
+  display:none; /* Hide default marker */
 }
 
-.note-toggle {
-  display: inline-block;
-  transition: transform 0.3s ease;
+
+.note-toggle{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  transition:transform 0.3s ease;
+  width:20px;
+  height:20px;
+  border-radius:6px;
+  border:1px solid var(--line);
+  background:#fff;
+  position:relative;
+  transform:rotate(0deg);
+  flex:0 0 20px;
 }
 
-details[open] .note-toggle {
-  transform: rotate(90deg);
+details[open] .note-toggle{
+  transform:rotate(90deg);
 }
 
-.note-preview {
-  display: block;
-  max-height: 50px;
-  overflow: hidden;
+.note-preview{
+  display:-webkit-box;
+  -webkit-box-orient:vertical;
+  -webkit-line-clamp: var(--clamp);
+  overflow:hidden;
+  color:#111827;
+  flex:1 1 auto;
+  min-width:0;
+  align-self:stretch;
 }
 
-.note-full {
-  display: block;
-  padding: 6px 0 0 28px;
-  color: #111827;
-  white-space: pre-wrap;
+.note-full{
+  display:block;
+  padding:6px 0 0 28px;
+  color:#111827;
+  white-space:pre-wrap;
 }
 
 /* Note details collapse */
@@ -589,6 +628,9 @@ details[open] .note-toggle {
     padding:10px 16px;
     gap:16px;
     align-items:flex-start;
+  }
+  .table tbody td.note{
+    padding:0;
   }
   .table tbody td::before{
     content: attr(data-label);

--- a/app/templates/tickets.html
+++ b/app/templates/tickets.html
@@ -20,9 +20,15 @@
 
     .note-preview-btn {
 
-      display: block;
+      display: flex;
+
+      align-items: center;
+
+      justify-content: flex-start;
 
       width: 100%;
+
+      height: 100%;
 
       text-align: left;
 
@@ -36,7 +42,7 @@
 
       border-radius: 0;
 
-      padding: 0;
+      padding: 12px;
 
       color: inherit;
 
@@ -65,6 +71,8 @@
       white-space: normal;
 
       overflow: visible;
+
+      align-items: flex-start;
 
     }
 


### PR DESCRIPTION
## Summary
- remove default table padding from note cells and update note containers to stretch with each row across breakpoints
- adjust the tickets note preview button styling so the interactive preview fills the cell and aligns multi-line content when expanded

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e56007a03083328fac8c588e6e2383