### PR TITLE
Require invoice number before marking ticket as sent

### DIFF
--- a/app/templates/tickets.html
+++ b/app/templates/tickets.html
@@ -1122,6 +1122,26 @@
 
         const next = sentCheckbox.checked ? 1 : 0;
 
+        if (next === 1){
+
+          const row = sentCheckbox.closest('tr');
+
+          const invoiceInput = row ? row.querySelector('.invoice-input') : null;
+
+          const invoiceValue = invoiceInput ? invoiceInput.value.trim() : '';
+
+          if (!invoiceValue){
+
+            window.alert('Enter an invoice number before marking as sent.');
+
+            sentCheckbox.checked = false;
+
+            return;
+
+          }
+
+        }
+
         const res = await safeFetch(`/api/v1/tickets/${id}`, {
 
           method: 'PATCH',


### PR DESCRIPTION
## Summary
- prevent marking a ticket as sent from the tickets table when no invoice number is filled in

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e589a50c388332aca770585c2e303d