### PR TITLE
Add modal for managing client custom attributes

### DIFF
--- a/app/routers/clients.py
+++ b/app/routers/clients.py
@@ -7,6 +7,11 @@ from ..services.clientsync import (
     get_client_entry,
     resolve_client_key,
 )
+from ..services.custom_attributes import (
+    add_custom_attribute_key,
+    load_custom_attribute_keys,
+    remove_custom_attribute_key,
+)
 from ..deps.auth import require_ui_or_token
 
 router = APIRouter(prefix="/api/v1/clients", tags=["clients"])
@@ -14,7 +19,15 @@ router = APIRouter(prefix="/api/v1/clients", tags=["clients"])
 # ---- Public READ endpoints (no token) ----
 @router.get("")
 def list_clients():
-    return {"clients": load_client_table()}
+    return {
+        "clients": load_client_table(),
+        "attribute_keys": load_custom_attribute_keys(),
+    }
+
+
+@router.get("/attributes")
+def list_custom_attributes():
+    return {"attribute_keys": load_custom_attribute_keys()}
 
 @router.get("/lookup")
 def get_client_by_name(name: str = Query(..., min_length=1, description="Client display name")):
@@ -84,3 +97,44 @@ def delete_client(client_key: str):
     table.pop(client_key, None)
     save_client_table(table)
     return {"status": "deleted", "client_key": client_key}
+
+
+@router.post("/attributes", dependencies=[Depends(require_ui_or_token)])
+def create_custom_attribute(payload: Dict[str, Any]):
+    key = (payload.get("key") or "").strip()
+    if not key:
+        raise HTTPException(422, "Missing 'key'")
+    try:
+        keys = add_custom_attribute_key(key)
+    except ValueError as exc:
+        raise HTTPException(422, str(exc)) from exc
+    except KeyError as exc:
+        raise HTTPException(409, str(exc)) from exc
+    return {"status": "created", "attribute_keys": keys}
+
+
+@router.delete("/attributes/{attribute_key}", dependencies=[Depends(require_ui_or_token)])
+def delete_custom_attribute(attribute_key: str):
+    key = (attribute_key or "").strip()
+    if not key:
+        raise HTTPException(422, "Invalid attribute key")
+    try:
+        keys = remove_custom_attribute_key(key)
+    except ValueError as exc:
+        raise HTTPException(422, str(exc)) from exc
+    except KeyError as exc:
+        raise HTTPException(404, str(exc)) from exc
+
+    table = load_client_table()
+    changed = False
+    for client_key, entry in list(table.items()):
+        if not isinstance(entry, dict):
+            continue
+        if key in entry:
+            entry.pop(key, None)
+            table[client_key] = entry
+            changed = True
+    if changed:
+        save_client_table(table)
+
+    return {"status": "deleted", "attribute_keys": keys}

--- a/app/services/custom_attributes.py
+++ b/app/services/custom_attributes.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, List, Set
+
+from ..core.config import settings
+
+# Keys that are considered demographic/built-in and should not be treated as custom attributes.
+DEMOGRAPHIC_ATTRIBUTE_KEYS: Set[str] = {
+    "address_line1",
+    "address_line2",
+    "city",
+    "state",
+    "postal_code",
+    "support_hours_allowance",
+    "primary_contact_name",
+    "primary_contact_phone",
+    "primary_contact_email",
+    "office_manager_name",
+    "office_manager_phone",
+    "office_manager_email",
+}
+
+# Other reserved keys that belong to client metadata and must not be managed as custom attributes.
+RESERVED_CLIENT_KEYS: Set[str] = {"name", "display_name", "key"} | DEMOGRAPHIC_ATTRIBUTE_KEYS
+
+
+def _file_path() -> Path:
+    return settings.DATA_DIR / "custom_attributes.json"
+
+
+def _discover_from_clients() -> Set[str]:
+    try:
+        from .clientsync import load_client_table  # Local import to avoid circular dependency
+    except ImportError:  # pragma: no cover - defensive fallback
+        return set()
+
+    table = load_client_table()
+    discovered: Set[str] = set()
+    for entry in table.values():
+        if not isinstance(entry, dict):
+            continue
+        for key in entry.keys():
+            if key not in RESERVED_CLIENT_KEYS:
+                discovered.add(str(key))
+    return discovered
+
+
+def _normalize_keys(raw: Iterable[str]) -> List[str]:
+    normalized: Set[str] = set()
+    for key in raw:
+        if not isinstance(key, str):
+            continue
+        cleaned = key.strip()
+        if not cleaned or cleaned in RESERVED_CLIENT_KEYS:
+            continue
+        normalized.add(cleaned)
+    return sorted(normalized)
+
+
+def load_custom_attribute_keys() -> List[str]:
+    path = _file_path()
+    keys: List[str] = []
+    if path.exists():
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(data, list):
+                keys = _normalize_keys(data)
+        except json.JSONDecodeError:
+            keys = []
+    if not keys:
+        keys = _normalize_keys(_discover_from_clients())
+        save_custom_attribute_keys(keys)
+    return keys
+
+
+def save_custom_attribute_keys(keys: Iterable[str]) -> List[str]:
+    normalized = _normalize_keys(keys)
+    settings.DATA_DIR.mkdir(parents=True, exist_ok=True)
+    path = _file_path()
+    path.write_text(json.dumps(normalized, indent=2, ensure_ascii=False), encoding="utf-8")
+    return normalized
+
+
+def add_custom_attribute_key(key: str) -> List[str]:
+    cleaned = (key or "").strip()
+    if not cleaned:
+        raise ValueError("Attribute key cannot be blank")
+    if cleaned in RESERVED_CLIENT_KEYS:
+        raise ValueError("Attribute key is reserved")
+    keys = load_custom_attribute_keys()
+    if cleaned in keys:
+        raise KeyError("Attribute key already exists")
+    keys.append(cleaned)
+    return save_custom_attribute_keys(keys)
+
+
+def remove_custom_attribute_key(key: str) -> List[str]:
+    cleaned = (key or "").strip()
+    if not cleaned:
+        raise ValueError("Attribute key cannot be blank")
+    keys = load_custom_attribute_keys()
+    if cleaned not in keys:
+        raise KeyError("Attribute key not found")
+    filtered = [k for k in keys if k != cleaned]
+    return save_custom_attribute_keys(filtered)

--- a/app/templates/clients.html
+++ b/app/templates/clients.html
@@ -13,6 +13,7 @@
     <div class="container">
       <h1>Clients</h1>
       <div class="actions">
+        <button class="btn" id="manage-attributes">Manage Custom Attributes</button>
         <button class="btn" id="create-client">New Client</button>
       </div>
       <nav class="links">
@@ -45,16 +46,27 @@
 
       <form id="edit-form" class="modal-form">
         <div id="edit-fields"></div>
-
-        <div class="form-inline">
-          <input type="text" id="new-key" placeholder="new attribute key" class="mono" />
-          <input type="text" id="new-val" placeholder="value" class="mono" />
-          <button class="btn" id="add-attr">Add attribute</button>
-        </div>
         <div class="form-actions">
           <button class="btn" type="submit">Save</button>
         </div>
       </form>
+    </div>
+  </div>
+
+  <div id="attributes-modal" class="modal-root" style="display:none;">
+    <div class="modal-card">
+      <header class="modal-head">
+        <h2 class="modal-title">Manage Custom Attributes</h2>
+        <button id="attributes-close" class="btn">Close</button>
+      </header>
+      <div class="modal-form">
+        <p class="modal-note">Custom attributes appear for every client. Removing one will delete its values for all clients.</p>
+        <div id="attributes-list" class="attribute-list"></div>
+        <form id="attribute-add-form" class="form-inline" style="margin-top:16px;">
+          <input type="text" id="attribute-new-key" placeholder="new attribute key" class="mono" />
+          <button class="btn" type="submit">Add attribute</button>
+        </form>
+      </div>
     </div>
   </div>
 
@@ -78,6 +90,7 @@ const ADDRESS_AUTOCOMPLETE_MIN_CHARS = 3;
 const ADDRESS_AUTOCOMPLETE_DEBOUNCE = 250;
 const ADDRESS_AUTOCOMPLETE_LIMIT = 20;
 let ADDRESS_AUTOCOMPLETE_DISABLED = false;
+let currentAttributeKeys = [];
 
 function getApiToken(){ return window.localStorage.getItem('api_token') || ''; }
 function setApiToken(t){ if (t) window.localStorage.setItem('api_token', t); }
@@ -416,13 +429,15 @@ function renderTable(data){
   head.innerHTML = '';
   body.innerHTML = '';
 
-  const attributeKeys = new Set();
+  const declaredAttributes = Array.isArray(data.attribute_keys) ? data.attribute_keys : [];
+  const attributeKeys = new Set(declaredAttributes);
   Object.values(tableData).forEach((entry) => {
     Object.keys(entry || {}).forEach((k) => {
       if (k !== 'name' && !DEMOGRAPHIC_KEYS.has(k)) attributeKeys.add(k);
     });
   });
   const sortedAttributes = Array.from(attributeKeys).sort();
+  currentAttributeKeys = sortedAttributes.slice();
 
   const trh = document.createElement('tr');
   ['Client Key', 'Name', ...sortedAttributes, 'Actions'].forEach((label) => {
@@ -642,28 +657,128 @@ function openEditor(clientKey, entry, attributeKeys){
     }
   };
 
-  document.getElementById('add-attr').onclick = (ev) => {
-    ev.preventDefault();
-    const newKeyInput = document.getElementById('new-key');
-    const newValInput = document.getElementById('new-val');
-    const key = (newKeyInput.value || '').trim();
-    if (!key) return;
-    const value = newValInput.value || '';
-    if (DEMOGRAPHIC_KEYS.has(key)){
-      const target = demographicsContainer.querySelector(`input[data-attr-key="${key}"]`);
-      if (target){
-        target.value = value;
-        target.dispatchEvent(new Event('input'));
-        target.focus();
+}
+
+const attributesModal = document.getElementById('attributes-modal');
+const attributesList = document.getElementById('attributes-list');
+const manageAttributesBtn = document.getElementById('manage-attributes');
+const attributesCloseBtn = document.getElementById('attributes-close');
+const attributeAddForm = document.getElementById('attribute-add-form');
+const attributeNewKeyInput = document.getElementById('attribute-new-key');
+
+function closeAttributesModal(){
+  if (attributesModal) attributesModal.style.display = 'none';
+}
+
+function renderAttributesManager(){
+  if (!attributesList) return;
+  attributesList.innerHTML = '';
+  if (!currentAttributeKeys.length){
+    const empty = document.createElement('p');
+    empty.textContent = 'No custom attributes yet.';
+    empty.style.margin = '8px 0';
+    attributesList.appendChild(empty);
+    return;
+  }
+  currentAttributeKeys.forEach((key) => {
+    const row = document.createElement('div');
+    row.style.display = 'flex';
+    row.style.alignItems = 'center';
+    row.style.justifyContent = 'space-between';
+    row.style.gap = '8px';
+    row.style.marginBottom = '6px';
+
+    const label = document.createElement('span');
+    label.textContent = key;
+    label.className = 'mono';
+    label.style.flex = '1';
+    row.appendChild(label);
+
+    const removeBtn = document.createElement('button');
+    removeBtn.type = 'button';
+    removeBtn.className = 'btn';
+    removeBtn.textContent = 'Remove';
+    removeBtn.addEventListener('click', async () => {
+      if (!confirm(`Remove attribute "${key}"? This will delete the value for all clients.`)) return;
+      try {
+        const res = await safeFetch(`/api/v1/clients/attributes/${encodeURIComponent(key)}`, {
+          method: 'DELETE',
+          headers: apiHeaders(false)
+        });
+        if (!res.ok){
+          throw new Error('Failed to remove attribute');
+        }
+        const data = await res.json();
+        currentAttributeKeys = Array.isArray(data.attribute_keys) ? data.attribute_keys.slice().sort((a, b) => a.localeCompare(b)) : currentAttributeKeys.filter((k) => k !== key);
+        renderAttributesManager();
+        loadTable();
+      } catch (err) {
+        console.error(err);
+        alert('Failed to remove attribute');
       }
-    } else {
-      addAttrRow(key, value);
-      const target = attrContainer.querySelector(`input[data-attr-key="${key}"]`);
-      if (target) target.focus();
+    });
+    row.appendChild(removeBtn);
+    attributesList.appendChild(row);
+  });
+}
+
+async function refreshAttributeKeysFromServer(){
+  const res = await safeFetch('/api/v1/clients/attributes');
+  if (!res.ok){
+    throw new Error('Failed to load custom attributes');
+  }
+  const data = await res.json();
+  currentAttributeKeys = Array.isArray(data.attribute_keys) ? data.attribute_keys.slice().sort((a, b) => a.localeCompare(b)) : [];
+  return currentAttributeKeys;
+}
+
+if (attributesCloseBtn){
+  attributesCloseBtn.addEventListener('click', closeAttributesModal);
+}
+
+if (manageAttributesBtn){
+  manageAttributesBtn.addEventListener('click', async () => {
+    try {
+      await refreshAttributeKeysFromServer();
+      renderAttributesManager();
+      if (attributesModal) attributesModal.style.display = 'block';
+    } catch (err) {
+      console.error(err);
+      alert('Failed to load custom attributes');
     }
-    newKeyInput.value = '';
-    newValInput.value = '';
-  };
+  });
+}
+
+if (attributeAddForm){
+  attributeAddForm.addEventListener('submit', async (ev) => {
+    ev.preventDefault();
+    const key = attributeNewKeyInput ? (attributeNewKeyInput.value || '').trim() : '';
+    if (!key) return;
+    try {
+      const res = await safeFetch('/api/v1/clients/attributes', {
+        method: 'POST',
+        headers: apiHeaders(true),
+        body: JSON.stringify({ key })
+      });
+      if (res.ok){
+        const data = await res.json();
+        currentAttributeKeys = Array.isArray(data.attribute_keys) ? data.attribute_keys.slice().sort((a, b) => a.localeCompare(b)) : currentAttributeKeys;
+        if (attributeNewKeyInput) attributeNewKeyInput.value = '';
+        renderAttributesManager();
+        loadTable();
+      } else if (res.status === 409){
+        alert('Attribute already exists');
+      } else if (res.status === 422){
+        const data = await res.json().catch(() => ({}));
+        alert(data.detail || 'Attribute key is invalid');
+      } else {
+        throw new Error('Failed to add attribute');
+      }
+    } catch (err) {
+      console.error(err);
+      alert('Failed to add attribute');
+    }
+  });
 }
 
 document.getElementById('create-client').addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- add a dedicated service for loading and persisting configurable client attribute keys
- extend client API endpoints to expose and manage custom attribute metadata and clean existing records when attributes are removed
- update the clients UI with a Manage Custom Attributes modal that controls add/remove actions and displays the configured fields across client edits

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5971128888332a68d886fabe3a698