### PR TITLE
Add inventory tracking and integrate with tickets

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -16,6 +16,11 @@ from .core.config import settings
 from .db.session import Base, engine
 from .db.migrate import run_migrations
 
+# Ensure models are registered with SQLAlchemy metadata before create_all.
+from .models import hardware as _hardware  # noqa: F401
+from .models import ticket as _ticket  # noqa: F401
+from .models import inventory as _inventory  # noqa: F401
+
 # ---------- App init ----------
 app = FastAPI(title="Time Tracker")
 
@@ -96,6 +101,9 @@ app.include_router(clients_router.router, prefix="")
 
 from .routers import api_hardware as api_hardware_router  # type: ignore
 app.include_router(api_hardware_router.router, prefix="")
+
+from .routers import api_inventory as api_inventory_router  # type: ignore
+app.include_router(api_inventory_router.router, prefix="")
 
 from .routers import address as address_router  # type: ignore
 app.include_router(address_router.router, prefix="")

--- a/app/crud/inventory.py
+++ b/app/crud/inventory.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import desc, func, select
+from sqlalchemy.orm import Session
+
+from ..models.inventory import InventoryEvent
+from ..models.hardware import Hardware
+
+
+def list_inventory_events(db: Session, limit: int = 100, offset: int = 0) -> list[InventoryEvent]:
+    stmt = (
+        select(InventoryEvent)
+        .order_by(desc(InventoryEvent.created_at), desc(InventoryEvent.id))
+        .limit(limit)
+        .offset(offset)
+    )
+    return db.execute(stmt).scalars().all()
+
+
+def get_inventory_summary(db: Session) -> list[dict[str, object]]:
+    stmt = (
+        select(
+            InventoryEvent.hardware_id,
+            Hardware.barcode,
+            Hardware.description,
+            func.coalesce(func.sum(InventoryEvent.change), 0).label("quantity"),
+            func.max(InventoryEvent.created_at).label("last_activity"),
+        )
+        .join(Hardware, Hardware.id == InventoryEvent.hardware_id)
+        .group_by(InventoryEvent.hardware_id, Hardware.barcode, Hardware.description)
+        .order_by(Hardware.description)
+    )
+    rows = db.execute(stmt).all()
+    return [
+        {
+            "hardware_id": row.hardware_id,
+            "barcode": row.barcode,
+            "description": row.description,
+            "quantity": int(row.quantity or 0),
+            "last_activity": row.last_activity,
+        }
+        for row in rows
+    ]
+
+
+def record_inventory_event(
+    db: Session,
+    *,
+    hardware_id: int,
+    change: int,
+    source: str = "manual",
+    note: str | None = None,
+    ticket_id: int | None = None,
+) -> InventoryEvent:
+    if not change:
+        raise ValueError("change must be non-zero")
+    event = InventoryEvent(
+        hardware_id=hardware_id,
+        change=change,
+        source=source,
+        note=note,
+        ticket_id=ticket_id,
+        created_at=datetime.utcnow().isoformat(timespec="seconds") + "Z",
+    )
+    db.add(event)
+    db.commit()
+    db.refresh(event)
+    return event
+
+
+def get_event_by_ticket(db: Session, ticket_id: int) -> InventoryEvent | None:
+    stmt = select(InventoryEvent).where(InventoryEvent.ticket_id == ticket_id)
+    return db.execute(stmt).scalars().first()
+
+
+def delete_event(db: Session, event: InventoryEvent) -> None:
+    db.delete(event)
+    db.commit()
+
+
+def delete_ticket_event(db: Session, ticket_id: int) -> None:
+    existing = get_event_by_ticket(db, ticket_id)
+    if existing:
+        delete_event(db, existing)
+
+
+def ensure_ticket_usage_event(
+    db: Session,
+    *,
+    ticket_id: int,
+    hardware_id: int,
+    quantity: int = 1,
+    note: str | None = None,
+) -> InventoryEvent:
+    """Create or update the inventory event associated with a hardware ticket.
+
+    ``quantity`` represents how many units were consumed by the ticket. The
+    stored change is always negative to reflect usage.
+    """
+
+    change = -abs(quantity)
+    existing = get_event_by_ticket(db, ticket_id)
+    if existing:
+        existing.hardware_id = hardware_id
+        existing.change = change
+        existing.source = "ticket"
+        existing.note = note
+        db.commit()
+        db.refresh(existing)
+        return existing
+
+    return record_inventory_event(
+        db,
+        hardware_id=hardware_id,
+        change=change,
+        source="ticket",
+        note=note,
+        ticket_id=ticket_id,
+    )

--- a/app/db/migrate.py
+++ b/app/db/migrate.py
@@ -76,6 +76,7 @@ def run_migrations(engine: Engine) -> None:
         "hardware_id": "INTEGER",
         "hardware_description": "TEXT",
         "hardware_sales_price": "TEXT",
+        "hardware_quantity": "INTEGER",
         "sent": "INTEGER DEFAULT 0 NOT NULL",
     }
 

--- a/app/models/inventory.py
+++ b/app/models/inventory.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from sqlalchemy import Column, ForeignKey, Integer, Text
+from sqlalchemy.orm import relationship
+
+from ..db.session import Base
+
+
+class InventoryEvent(Base):
+    """A change in inventory for a hardware item.
+
+    Positive ``change`` values represent stock being added while negatives
+    represent usage/consumption.
+    """
+
+    __tablename__ = "inventory_events"
+
+    id = Column(Integer, primary_key=True, index=True)
+    hardware_id = Column(Integer, ForeignKey("hardware.id"), nullable=False, index=True)
+    change = Column(Integer, nullable=False)
+    source = Column(Text, nullable=False, default="manual")
+    note = Column(Text, nullable=True)
+    created_at = Column(Text, nullable=False)
+    ticket_id = Column(Integer, ForeignKey("tickets.id"), nullable=True, index=True)
+
+    hardware = relationship("Hardware", lazy="joined")
+
+    @property
+    def hardware_barcode(self) -> str | None:
+        return self.hardware.barcode if self.hardware else None
+
+    @property
+    def hardware_description(self) -> str | None:
+        return self.hardware.description if self.hardware else None

--- a/app/models/ticket.py
+++ b/app/models/ticket.py
@@ -27,6 +27,7 @@ class Ticket(Base):
     hardware_id = Column(Integer, nullable=True, index=True)
     hardware_description = Column(Text, nullable=True)
     hardware_sales_price = Column(Text, nullable=True)
+    hardware_quantity = Column(Integer, nullable=True, default=1)
 
     @property
     def hardware_barcode(self) -> str | None:

--- a/app/routers/api_inventory.py
+++ b/app/routers/api_inventory.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from ..crud.inventory import get_inventory_summary, list_inventory_events, record_inventory_event
+from ..db.session import get_db
+from ..deps.auth import require_ui_or_token
+from ..models.hardware import Hardware
+from ..schemas.inventory import (
+    InventoryAdjustment,
+    InventoryEventOut,
+    InventorySummaryItem,
+)
+
+router = APIRouter(prefix="/api/v1/inventory", tags=["inventory"], dependencies=[Depends(require_ui_or_token)])
+
+
+def _lookup_hardware(db: Session, hardware_id: int | None, barcode: str | None) -> Hardware:
+    if hardware_id:
+        hw = db.get(Hardware, hardware_id)
+        if hw:
+            return hw
+    if barcode:
+        stmt = select(Hardware).where(Hardware.barcode == barcode.strip())
+        hw = db.execute(stmt).scalars().first()
+        if hw:
+            return hw
+    raise HTTPException(status_code=404, detail="Hardware item not found")
+
+
+@router.get("/summary", response_model=list[InventorySummaryItem])
+def api_inventory_summary(db: Session = Depends(get_db)):
+    return get_inventory_summary(db)
+
+
+@router.get("/events", response_model=list[InventoryEventOut])
+def api_inventory_events(limit: int = 100, offset: int = 0, db: Session = Depends(get_db)):
+    return list_inventory_events(db, limit=limit, offset=offset)
+
+
+@router.post("/receive", response_model=InventoryEventOut, status_code=201)
+def api_receive_inventory(payload: InventoryAdjustment, db: Session = Depends(get_db)):
+    hw = _lookup_hardware(db, payload.hardware_id, payload.barcode)
+    return record_inventory_event(
+        db,
+        hardware_id=hw.id,
+        change=payload.quantity,
+        source="api:receive",
+        note=payload.note,
+    )
+
+
+@router.post("/use", response_model=InventoryEventOut, status_code=201)
+def api_use_inventory(payload: InventoryAdjustment, db: Session = Depends(get_db)):
+    hw = _lookup_hardware(db, payload.hardware_id, payload.barcode)
+    return record_inventory_event(
+        db,
+        hardware_id=hw.id,
+        change=-payload.quantity,
+        source="api:use",
+        note=payload.note,
+    )

--- a/app/schemas/inventory.py
+++ b/app/schemas/inventory.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class InventoryAdjustment(BaseModel):
+    hardware_id: Optional[int] = None
+    barcode: Optional[str] = None
+    quantity: int = Field(gt=0)
+    note: Optional[str] = None
+
+    @model_validator(mode="after")
+    def validate_target(self) -> "InventoryAdjustment":
+        if not self.hardware_id and not (self.barcode and self.barcode.strip()):
+            raise ValueError("hardware_id or barcode is required")
+        return self
+
+
+class InventoryEventOut(BaseModel):
+    id: int
+    hardware_id: int
+    change: int
+    source: str
+    note: Optional[str]
+    created_at: str
+    ticket_id: Optional[int]
+    hardware_barcode: Optional[str] = None
+    hardware_description: Optional[str] = None
+
+    class Config:
+        from_attributes = True
+
+
+class InventorySummaryItem(BaseModel):
+    hardware_id: int
+    barcode: str
+    description: str
+    quantity: int
+    last_activity: Optional[str]

--- a/app/schemas/ticket.py
+++ b/app/schemas/ticket.py
@@ -10,6 +10,7 @@ class EntryBase(BaseModel):
     entry_type: str = Field(default="time", pattern="^(time|hardware)$")
     hardware_id: Optional[int] = None  # when entry_type == 'hardware'
     hardware_barcode: Optional[str] = None
+    hardware_quantity: Optional[int] = Field(default=None, ge=1)
 
 
 class EntryCreate(EntryBase):
@@ -31,6 +32,7 @@ class EntryUpdate(BaseModel):
     entry_type: Optional[str] = Field(default=None, pattern="^(time|hardware)$")
     hardware_id: Optional[int] = None
     hardware_barcode: Optional[str] = None
+    hardware_quantity: Optional[int] = Field(default=None, ge=1)
 
 
 class EntryOut(BaseModel):
@@ -53,6 +55,7 @@ class EntryOut(BaseModel):
     hardware_barcode: Optional[str] = None
     hardware_description: Optional[str] = None
     hardware_sales_price: Optional[str] = None
+    hardware_quantity: Optional[int] = None
 
     class Config:
         from_attributes = True

--- a/app/static/app.css
+++ b/app/static/app.css
@@ -83,6 +83,29 @@ body.dashboard{ background:#f4f6fb; color:var(--ink); font: 14px/1.45 system-ui,
 .card + .card{ margin-top:24px; }
 .card--filters{ padding:18px 18px 8px; }
 .card--table{ padding:0 0 8px; }
+.card__header{ padding:16px 18px; border-bottom:1px solid var(--line); }
+.card__title{ margin:0; font-size:16px; font-weight:600; color:var(--ink); }
+
+.inventory-layout{ display:grid; gap:24px; }
+@media (min-width:900px){
+  .inventory-layout{ grid-template-columns:repeat(2, minmax(0,1fr)); }
+}
+.inventory-layout .card{ padding:0; }
+.inventory-layout .card > .table-scroll,
+.inventory-layout .card > .inventory-form{ padding:18px; }
+.inventory-layout .card .empty{ text-align:center; padding:24px 0; color:var(--muted); }
+
+.inventory-form{ display:grid; gap:14px; }
+@media (min-width:600px){
+  .inventory-form{ grid-template-columns:repeat(2, minmax(0,1fr)); }
+}
+.inventory-form__field{ display:flex; flex-direction:column; gap:6px; }
+.inventory-form__field--wide{ grid-column:1 / -1; }
+.inventory-form__field span{ font-size:12px; color:var(--muted); }
+.inventory-form__field select,
+.inventory-form__field input{ height:36px; padding:0 10px; border:1px solid var(--line); border-radius:10px; background:#fff; color:var(--ink); }
+.inventory-form__actions{ display:flex; justify-content:flex-end; grid-column:1 / -1; }
+.inventory-form__actions .btn{ min-width:160px; }
 
 /* Filters grid */
 .filters-grid{

--- a/app/templates/clients.html
+++ b/app/templates/clients.html
@@ -21,6 +21,7 @@
         <a href="/" class="pill">Dashboard</a>
         <a href="/tickets" class="pill">Tickets</a>
         <a href="/hardware" class="pill">Hardware</a>
+        <a href="/inventory" class="pill">Inventory</a>
         <a href="/clients" class="pill active" aria-current="page">Clients</a>
       </nav>
     </div>

--- a/app/templates/hardware.html
+++ b/app/templates/hardware.html
@@ -18,6 +18,7 @@
         <a href="/" class="pill">Dashboard</a>
         <a href="/tickets" class="pill">Tickets</a>
         <a href="/hardware" class="pill active" aria-current="page">Hardware</a>
+        <a href="/inventory" class="pill">Inventory</a>
         <a href="/clients" class="pill">Clients</a>
       </nav>
     </div>

--- a/app/templates/inventory.html
+++ b/app/templates/inventory.html
@@ -1,0 +1,131 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Inventory</title>
+  <link rel="stylesheet" href="/static/app.css" />
+  <link rel="icon" href="/static/favicon.ico" />
+</head>
+<body class="dashboard">
+  <header class="app-header">
+    <div class="container">
+      <h1>Inventory</h1>
+      <nav class="links">
+        <a href="/" class="pill">Dashboard</a>
+        <a href="/tickets" class="pill">Tickets</a>
+        <a href="/hardware" class="pill">Hardware</a>
+        <a href="/inventory" class="pill active" aria-current="page">Inventory</a>
+        <a href="/clients" class="pill">Clients</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container inventory-layout">
+    <section class="card">
+      <header class="card__header">
+        <h2 class="card__title">Current stock</h2>
+      </header>
+      <div class="table-scroll">
+        <table class="table">
+          <thead>
+            <tr>
+              <th class="mono">Barcode</th>
+              <th>Description</th>
+              <th class="mono">On Hand</th>
+              <th class="mono">Last Activity</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% if summary %}
+              {% for item in summary %}
+              <tr>
+                <td class="mono">{{ item.barcode }}</td>
+                <td>{{ item.description }}</td>
+                <td class="mono">{{ item.quantity }}</td>
+                <td class="mono">{{ item.last_activity | fmt_dt }}</td>
+              </tr>
+              {% endfor %}
+            {% else %}
+              <tr>
+                <td colspan="4" class="empty">No inventory activity yet.</td>
+              </tr>
+            {% endif %}
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="card">
+      <header class="card__header">
+        <h2 class="card__title">Adjust inventory</h2>
+      </header>
+      <form method="post" action="/inventory/adjust" class="inventory-form">
+        <label class="inventory-form__field">
+          <span>Hardware item</span>
+          <select name="hardware_id" required>
+            <option value="" disabled selected>Select hardware</option>
+            {% for hardware in hardware_options %}
+              <option value="{{ hardware.id }}">{{ hardware.description }} ({{ hardware.barcode }})</option>
+            {% endfor %}
+          </select>
+        </label>
+        <label class="inventory-form__field">
+          <span>Action</span>
+          <select name="action">
+            <option value="receive">Receive stock</option>
+            <option value="use">Use stock</option>
+          </select>
+        </label>
+        <label class="inventory-form__field">
+          <span>Quantity</span>
+          <input name="quantity" type="number" min="1" value="1" required />
+        </label>
+        <label class="inventory-form__field inventory-form__field--wide">
+          <span>Note</span>
+          <input name="note" />
+        </label>
+        <div class="inventory-form__actions">
+          <button class="btn" type="submit">Save adjustment</button>
+        </div>
+      </form>
+    </section>
+
+    <section class="card">
+      <header class="card__header">
+        <h2 class="card__title">Recent activity</h2>
+      </header>
+      <div class="table-scroll">
+        <table class="table">
+          <thead>
+            <tr>
+              <th class="mono">When</th>
+              <th>Item</th>
+              <th class="mono">Change</th>
+              <th>Source</th>
+              <th>Note</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% if events %}
+              {% for event in events %}
+              <tr>
+                <td class="mono">{{ event.created_at | fmt_dt_compact }}</td>
+                <td>{{ event.hardware_description or 'Unknown' }}<br /><small class="mono">{{ event.hardware_barcode }}</small></td>
+                <td class="mono">{{ event.change }}</td>
+                <td>{{ event.source }}</td>
+                <td>{{ event.note }}</td>
+              </tr>
+              {% endfor %}
+            {% else %}
+              <tr>
+                <td colspan="5" class="empty">No activity yet.</td>
+              </tr>
+            {% endif %}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/app/templates/tickets.html
+++ b/app/templates/tickets.html
@@ -145,6 +145,7 @@
           <a href="/" class="pill">Dashboard</a>
           <a href="/tickets" class="pill active" aria-current="page">Tickets</a>
           <a href="/hardware" class="pill">Hardware</a>
+          <a href="/inventory" class="pill">Inventory</a>
           <a href="/clients" class="pill">Clients</a>
         </nav>
         <label class="pill pill-checkbox show-sent-toggle">


### PR DESCRIPTION
## Summary
- add an inventory events model, CRUD helpers, and API endpoints for receiving, using, and listing inventory activity
- surface inventory management in the UI with a new page, manual adjustment form, and styling updates, plus navigation links
- connect hardware tickets to inventory by persisting quantities, updating migrations, and syncing usage events automatically

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5adbd1fe4833287033e25f6d4c1c1