### PR TITLE
Add inventory counterparty tracking and hardware vendor analytics

### DIFF
--- a/app/core/jinja.py
+++ b/app/core/jinja.py
@@ -48,6 +48,14 @@ def _fmt_time(value: Any, fmt: str = "%I:%M %p") -> str:
     dt = _to_dt(value)
     return dt.strftime(fmt) if dt else ""
 
+
+def _fmt_currency(value: Any) -> str:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return ""
+    return f"${number:,.2f}"
+
 def get_templates() -> Jinja2Templates:
     """Create a Jinja2Templates instance with our standard filters registered."""
     templates = Jinja2Templates(directory=str(settings.TEMPLATES_DIR))
@@ -56,5 +64,6 @@ def get_templates() -> Jinja2Templates:
     env.filters["fmt_dt_compact"] = _fmt_dt_compact
     env.filters["fmt_date"] = _fmt_date
     env.filters["fmt_time"] = _fmt_time
+    env.filters["fmt_currency"] = _fmt_currency
     return templates
 

--- a/app/db/migrate.py
+++ b/app/db/migrate.py
@@ -107,3 +107,17 @@ def run_migrations(engine: Engine) -> None:
         )
 
     _create_index_if_not_exists(engine, "hardware", "ix_hardware_barcode_unique", ["barcode"], unique=True)
+
+    # Inventory event enrichments (vendor/client + costing)
+    inventory_table = _table_columns(engine, "inventory_events")
+    if inventory_table:
+        inventory_cols = {row["name"] for row in inventory_table}
+        new_cols = {
+            "counterparty_name": "TEXT",
+            "counterparty_type": "TEXT",
+            "actual_cost": "REAL",
+            "unit_cost": "REAL",
+        }
+        for name, dtype in new_cols.items():
+            if name not in inventory_cols:
+                _add_column_sqlite(engine, "inventory_events", f"{name} {dtype}")

--- a/app/models/inventory.py
+++ b/app/models/inventory.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sqlalchemy import Column, ForeignKey, Integer, Text
+from sqlalchemy import Column, Float, ForeignKey, Integer, Text
 from sqlalchemy.orm import relationship
 
 from ..db.session import Base
@@ -22,6 +22,10 @@ class InventoryEvent(Base):
     note = Column(Text, nullable=True)
     created_at = Column(Text, nullable=False)
     ticket_id = Column(Integer, ForeignKey("tickets.id"), nullable=True, index=True)
+    counterparty_name = Column(Text, nullable=True)
+    counterparty_type = Column(Text, nullable=True)
+    actual_cost = Column(Float, nullable=True)
+    unit_cost = Column(Float, nullable=True)
 
     hardware = relationship("Hardware", lazy="joined")
 

--- a/app/schemas/hardware.py
+++ b/app/schemas/hardware.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import Optional
 
 
@@ -28,6 +28,8 @@ class HardwareOut(BaseModel):
     acquisition_cost: Optional[str]
     sales_price: Optional[str]
     created_at: str
+    common_vendors: list[str] = Field(default_factory=list)
+    average_unit_cost: Optional[float] = None
 
     class Config:
         from_attributes = True

--- a/app/schemas/inventory.py
+++ b/app/schemas/inventory.py
@@ -10,6 +10,9 @@ class InventoryAdjustment(BaseModel):
     barcode: Optional[str] = None
     quantity: int = Field(gt=0)
     note: Optional[str] = None
+    vendor_name: Optional[str] = None
+    client_name: Optional[str] = None
+    actual_cost: Optional[float] = Field(default=None, ge=0)
 
     @model_validator(mode="after")
     def validate_target(self) -> "InventoryAdjustment":
@@ -28,6 +31,10 @@ class InventoryEventOut(BaseModel):
     ticket_id: Optional[int]
     hardware_barcode: Optional[str] = None
     hardware_description: Optional[str] = None
+    counterparty_name: Optional[str] = None
+    counterparty_type: Optional[str] = None
+    actual_cost: Optional[float] = None
+    unit_cost: Optional[float] = None
 
     class Config:
         from_attributes = True

--- a/app/templates/_hardware_rows.html
+++ b/app/templates/_hardware_rows.html
@@ -4,6 +4,16 @@
   <td data-label="Description">{{ r.description }}</td>
   <td class="mono" data-label="Acquisition Cost">{{ r.acquisition_cost or '' }}</td>
   <td class="mono" data-label="Sales Price">{{ r.sales_price or '' }}</td>
+  <td data-label="Common Vendors">
+    {% if r.common_vendors %}
+      {{ r.common_vendors | join(', ') }}
+    {% endif %}
+  </td>
+  <td class="mono" data-label="Avg Unit Cost">
+    {% if r.average_unit_cost is not none %}
+      {{ r.average_unit_cost | fmt_currency }}
+    {% endif %}
+  </td>
   <td class="mono" data-label="Created">{{ r.created_at|fmt_dt }}</td>
   <td class="td-action" data-label="Actions">
     <form action="/ui/hardware/{{ r.id }}/delete" method="post" class="inline">

--- a/app/templates/hardware.html
+++ b/app/templates/hardware.html
@@ -34,6 +34,8 @@
               <th>Description</th>
               <th class="mono">Acquisition Cost</th>
               <th class="mono">Sales Price</th>
+              <th>Common Vendors</th>
+              <th class="mono">Avg Unit Cost</th>
               <th class="mono">Created</th>
               <th class="th-action">Actions</th>
             </tr>

--- a/app/templates/inventory.html
+++ b/app/templates/inventory.html
@@ -81,6 +81,18 @@
           <span>Quantity</span>
           <input name="quantity" type="number" min="1" value="1" required />
         </label>
+        <label class="inventory-form__field">
+          <span>Vendor (receive)</span>
+          <input name="vendor_name" placeholder="Supplier name" />
+        </label>
+        <label class="inventory-form__field">
+          <span>Client (use)</span>
+          <input name="client_name" placeholder="Destination or client" />
+        </label>
+        <label class="inventory-form__field">
+          <span>Actual cost (total)</span>
+          <input name="actual_cost" type="number" step="0.01" min="0" placeholder="0.00" />
+        </label>
         <label class="inventory-form__field inventory-form__field--wide">
           <span>Note</span>
           <input name="note" />
@@ -104,6 +116,10 @@
               <th class="mono">Change</th>
               <th>Source</th>
               <th>Note</th>
+              <th>Counterparty</th>
+              <th class="mono">Actual cost</th>
+              <th class="mono">Unit cost</th>
+              <th class="th-action">Actions</th>
             </tr>
           </thead>
           <tbody>
@@ -115,11 +131,38 @@
                 <td class="mono">{{ event.change }}</td>
                 <td>{{ event.source }}</td>
                 <td>{{ event.note }}</td>
+                <td>
+                  {% if event.counterparty_name %}
+                    {{ event.counterparty_name }}
+                    {% if event.counterparty_type %}
+                      <br /><small class="tag">{{ event.counterparty_type }}</small>
+                    {% endif %}
+                  {% endif %}
+                </td>
+                <td class="mono">
+                  {% if event.actual_cost is not none %}
+                    {{ event.actual_cost | fmt_currency }}
+                  {% endif %}
+                </td>
+                <td class="mono">
+                  {% if event.unit_cost is not none %}
+                    {{ event.unit_cost | fmt_currency }}
+                  {% endif %}
+                </td>
+                <td class="td-action">
+                  <form action="/inventory/events/{{ event.id }}/delete" method="post" class="inline">
+                    <button class="btn btn-danger btn-icon" type="submit" aria-label="Delete inventory event {{ event.id }}">
+                      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                        <path fill="currentColor" d="M9 3a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1h5v2H4V3h5zm1 0h4v1h-4V3zM8 9h2v10H8V9zm4 0h2v10h-2V9zm4 0h2v10h-2V9z"/>
+                      </svg>
+                    </button>
+                  </form>
+                </td>
               </tr>
               {% endfor %}
             {% else %}
               <tr>
-                <td colspan="5" class="empty">No activity yet.</td>
+                <td colspan="9" class="empty">No activity yet.</td>
               </tr>
             {% endif %}
           </tbody>

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -1,0 +1,123 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("DATA_DIR", str(ROOT / "data"))
+
+from app.db.session import Base
+from app.crud.hardware import create_hardware, list_hardware
+from app.crud.inventory import record_inventory_event, list_inventory_events, delete_event
+
+# Ensure models are imported so metadata is populated
+from app.models import hardware as hardware_model  # noqa: F401
+from app.models import inventory as inventory_model  # noqa: F401
+
+
+@pytest.fixture()
+def db_session():
+    engine = create_engine("sqlite://", connect_args={"check_same_thread": False})
+    TestingSessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def test_record_inventory_event_tracks_costs(db_session):
+    hardware = create_hardware(
+        db_session,
+        {"barcode": "ABC123", "description": "Widget"},
+    )
+
+    event = record_inventory_event(
+        db_session,
+        hardware_id=hardware.id,
+        change=4,
+        source="ui:receive",
+        note="Initial stock",
+        counterparty_name="Vendor A",
+        counterparty_type="vendor",
+        actual_cost=100.0,
+    )
+
+    assert event.counterparty_name == "Vendor A"
+    assert event.counterparty_type == "vendor"
+    assert event.actual_cost == pytest.approx(100.0)
+    assert event.unit_cost == pytest.approx(25.0)
+
+
+def test_hardware_common_vendors_and_average_cost(db_session):
+    hardware = create_hardware(
+        db_session,
+        {"barcode": "XYZ789", "description": "Gadget"},
+    )
+
+    record_inventory_event(
+        db_session,
+        hardware_id=hardware.id,
+        change=4,
+        source="ui:receive",
+        note="Vendor A shipment",
+        counterparty_name="Vendor A",
+        counterparty_type="vendor",
+        actual_cost=100.0,
+    )
+    record_inventory_event(
+        db_session,
+        hardware_id=hardware.id,
+        change=2,
+        source="ui:receive",
+        note="Vendor B shipment",
+        counterparty_name="Vendor B",
+        counterparty_type="vendor",
+        actual_cost=60.0,
+    )
+    record_inventory_event(
+        db_session,
+        hardware_id=hardware.id,
+        change=-2,
+        source="ui:use",
+        note="Used by client",
+        counterparty_name="Client A",
+        counterparty_type="client",
+    )
+
+    rows = list_hardware(db_session, limit=10)
+    assert rows
+    gadget = next(row for row in rows if row.id == hardware.id)
+    assert gadget.common_vendors == ["Vendor A", "Vendor B"]
+    assert gadget.average_unit_cost == pytest.approx((25.0 + 30.0) / 2)
+
+
+def test_delete_inventory_event(db_session):
+    hardware = create_hardware(
+        db_session,
+        {"barcode": "DEL123", "description": "Disposable"},
+    )
+    event = record_inventory_event(
+        db_session,
+        hardware_id=hardware.id,
+        change=1,
+        source="ui:receive",
+        counterparty_name="Vendor D",
+        counterparty_type="vendor",
+        actual_cost=10.0,
+    )
+
+    events_before = list_inventory_events(db_session)
+    assert any(e.id == event.id for e in events_before)
+
+    delete_event(db_session, event)
+
+    events_after = list_inventory_events(db_session)
+    assert all(e.id != event.id for e in events_after)


### PR DESCRIPTION
## Summary
- extend inventory events with vendor/client counterparty and cost tracking, expose deletion in the API and UI
- surface common vendors and average per-unit costs for hardware listings with supporting currency formatting
- add tests covering inventory cost calculations, hardware vendor aggregation, and event deletion

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e5ed814ad88332a8866c4fbb07188b