### PR TITLE
Add hardware sales price column to tickets table

### DIFF
--- a/app/templates/_row.html
+++ b/app/templates/_row.html
@@ -7,10 +7,12 @@
   <td class="mono">{{ r.rounded_minutes }}</td>
   <td class="mono">{{ r.rounded_hours|hours2d }}</td>
 
+  <td class="mono">{{ r.hardware_sales_price or '' }}</td>
+
   <td class="note">
     {% if r.entry_type == 'hardware' %}
       <div class="note-cell">
-        <div class="note-preview"><strong>{{ r.hardware_description or '(no description)' }}</strong>{% if r.hardware_sales_price %} — {{ r.hardware_sales_price }}{% endif %}</div>
+        <div class="note-preview"><strong>{{ r.hardware_description or '(no description)' }}</strong></div>
       </div>
     {% else %}
       <div class="note-cell {% if r.note %}collapsed{% endif %}">

--- a/app/templates/_rows.html
+++ b/app/templates/_rows.html
@@ -12,10 +12,11 @@
   <td class="mono" data-label="Minutes">{{ r.minutes }}</td>
   <td class="mono" data-label="Rounded Hrs">{{ r.rounded_hours }}</td>
   <td class="mono" data-label="Type">{{ r.entry_type }}</td>
+  <td class="mono" data-label="Hardware Price">{{ r.hardware_sales_price or '' }}</td>
   <td class="note" data-label="Notes / Hardware" data-full-note="{{ (r.note or '')|escape }}" data-is-hardware="{{ 1 if r.entry_type == 'hardware' else 0 }}">
     <button class="note-preview-btn" type="button">
       {% if r.entry_type == 'hardware' %}
-        <strong>{{ r.hardware_description or '(no description)' }}</strong>{% if r.hardware_sales_price %} - {{ r.hardware_sales_price }}{% endif %}
+        <strong>{{ r.hardware_description or '(no description)' }}</strong>
       {% else %}
         {{ r.note or '' }}
       {% endif %}

--- a/app/templates/tickets.html
+++ b/app/templates/tickets.html
@@ -188,6 +188,8 @@
 
               <th class="mono">Type</th>
 
+              <th class="mono">Hardware Price</th>
+
               <th>Notes / Hardware</th>
 
               <th class="mono">Invoice</th>


### PR DESCRIPTION
## Summary
- add a dedicated hardware sales price column to the tickets table header and row partials
- simplify hardware note previews now that the sales price is displayed in its own column

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e607a469348332b917ff238a3e6142