### PR TITLE
feat: add project containers and dashboard

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -30,6 +30,7 @@ from .db.migrate import run_migrations
 from .models import hardware as _hardware  # noqa: F401
 from .models import ticket as _ticket  # noqa: F401
 from .models import inventory as _inventory  # noqa: F401
+from .models import project as _project  # noqa: F401
 
 # ---------- App init ----------
 # The FastAPI instance is the beating heart of the project. Once created it
@@ -162,6 +163,10 @@ app.include_router(api_inventory_router.router, prefix="")
 from .routers import address as address_router  # type: ignore
 
 app.include_router(address_router.router, prefix="")
+
+from .routers import api_projects as api_projects_router  # type: ignore
+
+app.include_router(api_projects_router.router, prefix="")
 
 # ---------- Exception handling ----------
 # This catch-all handler ensures the browser-friendly login redirect happens

--- a/app/crud/projects.py
+++ b/app/crud/projects.py
@@ -1,0 +1,130 @@
+"""CRUD helpers for project containers and their staged tickets."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import desc, select
+from sqlalchemy.orm import Session, selectinload
+
+from ..models.project import Project
+from ..models.ticket import Ticket
+from ..services.clientsync import resolve_client_name
+from .tickets import (
+    create_entry,
+    delete_ticket,
+    list_project_tickets,
+    update_ticket,
+)
+
+
+def _utcnow() -> str:
+    return datetime.utcnow().isoformat(timespec="seconds") + "Z"
+
+
+def list_projects(db: Session, limit: int = 200, offset: int = 0):
+    stmt = (
+        select(Project)
+        .options(selectinload(Project.tickets))
+        .order_by(desc(Project.created_at))
+        .limit(limit)
+        .offset(offset)
+    )
+    return db.execute(stmt).scalars().all()
+
+
+def get_project(db: Session, project_id: int) -> Project | None:
+    stmt = select(Project).options(selectinload(Project.tickets)).where(Project.id == project_id)
+    return db.execute(stmt).scalars().first()
+
+
+def create_project(db: Session, payload: dict) -> Project:
+    name = (payload.get("name") or "").strip()
+    if not name:
+        raise ValueError("name is required")
+    client_key = (payload.get("client_key") or "").strip()
+    if not client_key:
+        raise ValueError("client_key is required")
+    client = (payload.get("client") or "").strip() or resolve_client_name(client_key)
+    if not client:
+        raise ValueError("client could not be resolved from client_key")
+    now = _utcnow()
+    project = Project(
+        name=name,
+        client_key=client_key,
+        client=client,
+        status=(payload.get("status") or None),
+        note=(payload.get("note") or None),
+        start_date=(payload.get("start_date") or None),
+        end_date=(payload.get("end_date") or None),
+        created_at=now,
+        updated_at=now,
+        finalized_at=(payload.get("finalized_at") or None),
+    )
+    db.add(project)
+    db.commit()
+    db.refresh(project)
+    return project
+
+
+def update_project(db: Session, project: Project, payload: dict) -> Project:
+    if "name" in payload:
+        name = (payload.get("name") or "").strip()
+        if not name:
+            raise ValueError("name is required")
+        project.name = name
+    if "client_key" in payload or "client" in payload:
+        client_key = (payload.get("client_key") or project.client_key or "").strip()
+        if not client_key:
+            raise ValueError("client_key is required")
+        client = (payload.get("client") or "").strip() or resolve_client_name(client_key)
+        if not client:
+            raise ValueError("client could not be resolved from client_key")
+        project.client_key = client_key
+        project.client = client
+    for field in ("status", "note", "start_date", "end_date", "finalized_at"):
+        if field in payload:
+            value = payload.get(field)
+            project.__setattr__(field, value or None)
+    project.updated_at = _utcnow()
+    db.commit()
+    db.refresh(project)
+    return project
+
+
+def delete_project(db: Session, project: Project) -> None:
+    # Remove project-only tickets (not yet posted). Posted tickets stay in history.
+    staged = db.execute(
+        select(Ticket).where(Ticket.project_id == project.id, Ticket.project_posted == 0)
+    ).scalars().all()
+    for ticket in staged:
+        delete_ticket(db, ticket)
+    posted = db.execute(
+        select(Ticket).where(Ticket.project_id == project.id, Ticket.project_posted == 1)
+    ).scalars().all()
+    for ticket in posted:
+        ticket.project_id = None
+    db.delete(project)
+    db.commit()
+
+
+def finalize_project(db: Session, project: Project) -> Project:
+    tickets = list_project_tickets(db, project.id, include_posted=False)
+    for ticket in tickets:
+        update_ticket(db, ticket, {"project_posted": 1})
+    project.status = project.status or "finalized"
+    project.finalized_at = _utcnow()
+    project.updated_at = project.finalized_at
+    db.commit()
+    db.refresh(project)
+    return project
+
+
+def add_project_ticket(db: Session, project: Project, payload: dict):
+    data = dict(payload)
+    data["project_id"] = project.id
+    data["project_posted"] = 0
+    data["client_key"] = project.client_key
+    data["client"] = project.client
+    return create_entry(db, data)
+*** End File

--- a/app/models/project.py
+++ b/app/models/project.py
@@ -1,0 +1,32 @@
+"""SQLAlchemy model for project containers that group related tickets."""
+
+from __future__ import annotations
+
+from sqlalchemy import Column, Integer, Text
+from sqlalchemy.orm import relationship
+
+from ..db.session import Base
+
+
+class Project(Base):
+    """High level project that groups multiple tickets for a single client."""
+
+    __tablename__ = "projects"
+    __allow_unmapped__ = True
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(Text, nullable=False)
+    client = Column(Text, nullable=False)
+    client_key = Column(Text, nullable=False, index=True)
+    status = Column(Text, nullable=True)
+    note = Column(Text, nullable=True)
+    start_date = Column(Text, nullable=True)
+    end_date = Column(Text, nullable=True)
+    created_at = Column(Text, nullable=False)
+    updated_at = Column(Text, nullable=False)
+    finalized_at = Column(Text, nullable=True)
+
+    tickets = relationship("Ticket", back_populates="project")
+
+
+__all__ = ["Project"]

--- a/app/models/ticket.py
+++ b/app/models/ticket.py
@@ -11,7 +11,8 @@ File: app/models/ticket.py
 
 from __future__ import annotations
 import json
-from sqlalchemy import Column, Integer, Text
+from sqlalchemy import Column, ForeignKey, Integer, Text
+from sqlalchemy.orm import relationship
 from ..db.session import Base
 
 
@@ -35,6 +36,9 @@ class Ticket(Base):
     minutes = Column(Integer, nullable=False, default=0)
     entry_type = Column(Text, nullable=False, default="time")
 
+    project_id = Column(Integer, ForeignKey("projects.id"), nullable=True, index=True)
+    project_posted = Column(Integer, nullable=False, default=0)
+
     # Link & snapshot when entry_type == 'hardware'
     hardware_id = Column(Integer, nullable=True, index=True)
     hardware_description = Column(Text, nullable=True)
@@ -47,6 +51,8 @@ class Ticket(Base):
     invoiced_total = Column(Text, nullable=True)
     calculated_value = Column(Text, nullable=True)
     attachments_blob = Column("attachments", Text, nullable=True)
+
+    project = relationship("Project", back_populates="tickets")
 
     @property
     def hardware_barcode(self) -> str | None:

--- a/app/routers/api_projects.py
+++ b/app/routers/api_projects.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from ..crud.projects import (
+    add_project_ticket,
+    create_project,
+    delete_project,
+    finalize_project,
+    get_project,
+    list_projects,
+    update_project,
+)
+from ..crud.tickets import (
+    get_ticket,
+    list_project_tickets,
+    list_ticket_attachments,
+    update_ticket,
+    delete_ticket,
+)
+from ..db.session import get_db
+from ..deps.auth import require_ui_or_token
+from ..schemas.project import ProjectCreate, ProjectDetail, ProjectOut, ProjectUpdate
+from ..schemas.ticket import EntryCreate, EntryOut, EntryUpdate, TicketAttachment
+
+router = APIRouter(prefix="/api/v1/projects", tags=["projects"], dependencies=[Depends(require_ui_or_token)])
+
+
+def _attachment_to_schema(ticket_id: int, record: dict[str, object]) -> TicketAttachment:
+    payload = dict(record)
+    attachment_id = payload.get("id")
+    if attachment_id is not None:
+        payload["id"] = str(attachment_id)
+        payload["url"] = f"/api/v1/tickets/{ticket_id}/attachments/{attachment_id}"
+    else:
+        payload["id"] = ""
+        payload["url"] = f"/api/v1/tickets/{ticket_id}/attachments/{attachment_id}"
+    return TicketAttachment.model_validate(payload)
+
+
+def _ticket_to_schema(ticket) -> EntryOut:
+    payload = EntryOut.model_validate(ticket, from_attributes=True)
+    attachment_records = list_ticket_attachments(ticket)
+    payload.attachments = [
+        _attachment_to_schema(ticket.id, record) for record in attachment_records
+    ]
+    return payload
+
+
+def _project_to_schema(project, *, include_tickets: bool = False) -> ProjectOut | ProjectDetail:
+    tickets = list(project.tickets or [])
+    open_count = sum(1 for t in tickets if not t.project_posted)
+    posted_count = sum(1 for t in tickets if t.project_posted)
+    base = ProjectOut.model_validate(
+        project,
+        from_attributes=True,
+    ).model_copy(
+        update={
+            "open_ticket_count": open_count,
+            "posted_ticket_count": posted_count,
+            "ticket_count": len(tickets),
+        }
+    )
+    if not include_tickets:
+        return base
+    detail = ProjectDetail(**base.model_dump())
+    detail.tickets = [_ticket_to_schema(ticket) for ticket in tickets]
+    return detail
+
+
+@router.get("", response_model=list[ProjectOut])
+def api_list_projects(db: Session = Depends(get_db)):
+    projects = list_projects(db)
+    return [_project_to_schema(project) for project in projects]
+
+
+@router.post("", response_model=ProjectOut, status_code=201)
+def api_create_project(payload: ProjectCreate, db: Session = Depends(get_db)):
+    try:
+        project = create_project(db, payload.model_dump(exclude_unset=True))
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    project = get_project(db, project.id) or project
+    return _project_to_schema(project)
+
+
+@router.get("/{project_id}", response_model=ProjectDetail)
+def api_get_project(project_id: int, db: Session = Depends(get_db)):
+    project = get_project(db, project_id)
+    if not project:
+        raise HTTPException(404, "Not found")
+    return _project_to_schema(project, include_tickets=True)
+
+
+@router.patch("/{project_id}", response_model=ProjectOut)
+def api_update_project(project_id: int, payload: ProjectUpdate, db: Session = Depends(get_db)):
+    project = get_project(db, project_id)
+    if not project:
+        raise HTTPException(404, "Not found")
+    try:
+        updated = update_project(db, project, payload.model_dump(exclude_unset=True))
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    refreshed = get_project(db, updated.id) or updated
+    return _project_to_schema(refreshed)
+
+
+@router.delete("/{project_id}")
+def api_delete_project(project_id: int, db: Session = Depends(get_db)):
+    project = get_project(db, project_id)
+    if not project:
+        raise HTTPException(404, "Not found")
+    delete_project(db, project)
+    return {"status": "deleted"}
+
+
+@router.post("/{project_id}/finalize", response_model=ProjectOut)
+def api_finalize_project(project_id: int, db: Session = Depends(get_db)):
+    project = get_project(db, project_id)
+    if not project:
+        raise HTTPException(404, "Not found")
+    finalized = finalize_project(db, project)
+    refreshed = get_project(db, finalized.id) or finalized
+    return _project_to_schema(refreshed)
+
+
+@router.get("/{project_id}/tickets", response_model=list[EntryOut])
+def api_list_project_tickets(project_id: int, db: Session = Depends(get_db)):
+    project = get_project(db, project_id)
+    if not project:
+        raise HTTPException(404, "Not found")
+    tickets = list_project_tickets(db, project.id)
+    return [_ticket_to_schema(ticket) for ticket in tickets]
+
+
+@router.post("/{project_id}/tickets", response_model=EntryOut, status_code=201)
+def api_add_project_ticket(project_id: int, payload: EntryCreate, db: Session = Depends(get_db)):
+    project = get_project(db, project_id)
+    if not project:
+        raise HTTPException(404, "Not found")
+    try:
+        ticket = add_project_ticket(db, project, payload.model_dump(exclude_unset=True))
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return _ticket_to_schema(ticket)
+
+
+@router.patch("/{project_id}/tickets/{ticket_id}", response_model=EntryOut)
+def api_update_project_ticket(project_id: int, ticket_id: int, payload: EntryUpdate, db: Session = Depends(get_db)):
+    project = get_project(db, project_id)
+    if not project:
+        raise HTTPException(404, "Not found")
+    ticket = get_ticket(db, ticket_id)
+    if not ticket or ticket.project_id != project.id:
+        raise HTTPException(404, "Not found")
+    data = payload.model_dump(exclude_unset=True)
+    data["project_id"] = project.id
+    try:
+        updated = update_ticket(db, ticket, data)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return _ticket_to_schema(updated)
+
+
+@router.delete("/{project_id}/tickets/{ticket_id}")
+def api_delete_project_ticket(project_id: int, ticket_id: int, db: Session = Depends(get_db)):
+    project = get_project(db, project_id)
+    if not project:
+        raise HTTPException(404, "Not found")
+    ticket = get_ticket(db, ticket_id)
+    if not ticket or ticket.project_id != project.id:
+        raise HTTPException(404, "Not found")
+    delete_ticket(db, ticket)
+    return {"status": "deleted"}

--- a/app/schemas/project.py
+++ b/app/schemas/project.py
@@ -1,0 +1,52 @@
+"""Pydantic schemas that describe project payloads for the API."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+from .ticket import EntryOut
+
+
+class ProjectBase(BaseModel):
+    name: str
+    client_key: str
+    client: Optional[str] = None
+    status: Optional[str] = None
+    note: Optional[str] = None
+    start_date: Optional[str] = None
+    end_date: Optional[str] = None
+
+
+class ProjectCreate(ProjectBase):
+    pass
+
+
+class ProjectUpdate(BaseModel):
+    name: Optional[str] = None
+    client_key: Optional[str] = None
+    client: Optional[str] = None
+    status: Optional[str] = None
+    note: Optional[str] = None
+    start_date: Optional[str] = None
+    end_date: Optional[str] = None
+    finalized_at: Optional[str] = None
+
+
+class ProjectOut(ProjectBase):
+    id: int
+    created_at: str
+    updated_at: str
+    finalized_at: Optional[str] = None
+    open_ticket_count: int = 0
+    posted_ticket_count: int = 0
+    ticket_count: int = 0
+
+    class Config:
+        from_attributes = True
+
+
+class ProjectDetail(ProjectOut):
+    tickets: list[EntryOut] = Field(default_factory=list)
+*** End File

--- a/app/schemas/ticket.py
+++ b/app/schemas/ticket.py
@@ -26,6 +26,7 @@ class EntryBase(BaseModel):
     hardware_sales_price: Optional[str] = None
     flat_rate_amount: Optional[str] = None
     flat_rate_quantity: Optional[int] = Field(default=None, ge=1)
+    project_id: Optional[int] = None
 
 
 class EntryCreate(EntryBase):
@@ -34,6 +35,7 @@ class EntryCreate(EntryBase):
     invoice_number: Optional[str] = None
     sent: Optional[int] = 0
     invoiced_total: Optional[str] = None
+    project_posted: Optional[bool] = None
 
 
 class EntryUpdate(BaseModel):
@@ -54,6 +56,8 @@ class EntryUpdate(BaseModel):
     hardware_sales_price: Optional[str] = None
     flat_rate_amount: Optional[str] = None
     flat_rate_quantity: Optional[int] = Field(default=None, ge=1)
+    project_id: Optional[int] = None
+    project_posted: Optional[bool] = None
 
 
 class TicketAttachment(BaseModel):
@@ -94,6 +98,8 @@ class EntryOut(BaseModel):
     flat_rate_quantity: Optional[int] = None
     calculated_value: Optional[str] = None
     attachments: list[TicketAttachment] = Field(default_factory=list)
+    project_id: Optional[int] = None
+    project_posted: int
 
     class Config:
         from_attributes = True

--- a/app/templates/_project_records.html
+++ b/app/templates/_project_records.html
@@ -1,0 +1,34 @@
+{% if projects %}
+  {% for project in projects %}
+    <tr class="row" data-project-id="{{ project.id }}">
+      <td class="mono">{{ project.id }}</td>
+      <td>{{ project.name }}</td>
+      <td>{{ project.client }}</td>
+      <td class="mono">{{ project.status or "Draft" }}</td>
+      <td class="mono">{{ project.open_ticket_count }}</td>
+      <td class="mono">{{ project.posted_ticket_count }}</td>
+      <td class="mono">{{ project.created_at|fmt_dt }}</td>
+      <td class="mono">{{ project.updated_at|fmt_dt }}</td>
+      <td class="th-action">
+        <div class="actions-inline">
+          <a class="btn-ghost" href="/api/v1/projects/{{ project.id }}" target="_blank" rel="noreferrer">JSON</a>
+          {% if project.open_ticket_count > 0 %}
+            <button class="btn" type="button" data-action="finalize-project" data-project-id="{{ project.id }}">Finalize</button>
+          {% else %}
+            <span class="badge">Complete</span>
+          {% endif %}
+        </div>
+      </td>
+    </tr>
+    {% if project.note %}
+      <tr class="row row-note">
+        <td></td>
+        <td colspan="8" class="note">{{ project.note }}</td>
+      </tr>
+    {% endif %}
+  {% endfor %}
+{% else %}
+  <tr>
+    <td colspan="9" class="empty">No projects yet. Use the New Project button to get started.</td>
+  </tr>
+{% endif %}

--- a/app/templates/clients.html
+++ b/app/templates/clients.html
@@ -33,6 +33,7 @@
       <nav class="links">
         <a href="/" class="pill">Dashboard</a>
         <a href="/tickets" class="pill">Tickets</a>
+        <a href="/projects" class="pill">Projects</a>
         <a href="/hardware" class="pill">Hardware</a>
         <a href="/inventory" class="pill">Inventory</a>
         <a href="/clients" class="pill active" aria-current="page">Clients</a>

--- a/app/templates/hardware.html
+++ b/app/templates/hardware.html
@@ -29,6 +29,7 @@
       <nav class="links">
         <a href="/" class="pill">Dashboard</a>
         <a href="/tickets" class="pill">Tickets</a>
+        <a href="/projects" class="pill">Projects</a>
         <a href="/hardware" class="pill active" aria-current="page">Hardware</a>
         <a href="/inventory" class="pill">Inventory</a>
         <a href="/clients" class="pill">Clients</a>

--- a/app/templates/inventory.html
+++ b/app/templates/inventory.html
@@ -26,6 +26,7 @@
       <nav class="links">
         <a href="/" class="pill">Dashboard</a>
         <a href="/tickets" class="pill">Tickets</a>
+        <a href="/projects" class="pill">Projects</a>
         <a href="/hardware" class="pill">Hardware</a>
         <a href="/inventory" class="pill active" aria-current="page">Inventory</a>
         <a href="/clients" class="pill">Clients</a>

--- a/app/templates/projects.html
+++ b/app/templates/projects.html
@@ -1,0 +1,180 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Projects</title>
+  <link rel="stylesheet" href="/static/app.css" />
+  <link rel="icon" href="/static/favicon.ico" />
+</head>
+<body class="dashboard">
+  <header class="app-header">
+    <div class="container">
+      <div class="branding">
+        <img
+          src="/static/img/vip-full-hd-transparant-cropped-halfsize.png"
+          srcset="/static/img/vip-full-hd-transparant-cropped-halfsize.png 1x, /static/img/vip-full-hd-transparant-384x150.png 2x"
+          alt="VIP Clouds logo"
+          class="branding__logo"
+        />
+        <div class="branding__meta">
+          <span class="branding__kicker">VIP Clouds</span>
+          <h1 class="logo"><a href="/">Time Tracker</a></h1>
+        </div>
+      </div>
+      <h2 class="page-title">Projects</h2>
+      <div class="actions">
+        <button class="btn" type="button" id="new-project">New Project</button>
+        <button class="btn-ghost" type="button" id="refresh-projects">Refresh</button>
+      </div>
+      <nav class="links">
+        <a href="/" class="pill">Dashboard</a>
+        <a href="/tickets" class="pill">Tickets</a>
+        <a href="/projects" class="pill active" aria-current="page">Projects</a>
+        <a href="/hardware" class="pill">Hardware</a>
+        <a href="/inventory" class="pill">Inventory</a>
+        <a href="/clients" class="pill">Clients</a>
+        <a href="/reports" class="pill">Reports</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container">
+    <section class="table-wrap">
+      <div class="table-scroll">
+        <table class="table projects-table">
+          <thead>
+            <tr>
+              <th class="mono">ID</th>
+              <th>Project</th>
+              <th>Client</th>
+              <th class="mono">Status</th>
+              <th class="mono">Open Items</th>
+              <th class="mono">Posted</th>
+              <th class="mono">Created</th>
+              <th class="mono">Updated</th>
+              <th class="th-action">Actions</th>
+            </tr>
+          </thead>
+          <tbody id="project-records">
+            {% include "_project_records.html" with context %}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  </main>
+
+  <div id="project-modal" class="modal-root" style="display:none;">
+    <div class="modal-card modal-card--medium">
+      <header class="modal-head">
+        <h2 class="modal-title">New Project</h2>
+        <button id="project-modal-close" class="btn" type="button">Close</button>
+      </header>
+      <form id="project-form" class="modal-form">
+        <div class="form-grid two-column">
+          <label>Project Name<input name="name" required /></label>
+          <label>Client Key<input name="client_key" required /></label>
+          <label>Client Name<input name="client" placeholder="Optional override" /></label>
+          <label>Status<input name="status" placeholder="Draft" /></label>
+          <label>Start Date<input name="start_date" type="date" /></label>
+          <label>End Date<input name="end_date" type="date" /></label>
+          <label class="full-width">Notes<textarea name="note" rows="4"></textarea></label>
+        </div>
+        <div class="form-actions">
+          <button class="btn" type="submit">Save</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <script>
+  (function(){
+    const modal = document.getElementById('project-modal');
+    const openBtn = document.getElementById('new-project');
+    const closeBtn = document.getElementById('project-modal-close');
+    const form = document.getElementById('project-form');
+    const tableBody = document.getElementById('project-records');
+    const refreshBtn = document.getElementById('refresh-projects');
+
+    function getApiToken(){ return window.localStorage.getItem('api_token') || ''; }
+    function setApiToken(token){ if (token) window.localStorage.setItem('api_token', token); }
+    function apiHeaders(json=true){
+      const headers = {};
+      if (json) headers['Content-Type'] = 'application/json';
+      const token = getApiToken();
+      if (token) headers['X-API-Key'] = token;
+      return headers;
+    }
+
+    async function safeFetch(url, options={}, retry=true){
+      const opts = Object.assign({ credentials: 'same-origin' }, options);
+      const wantsJson = Boolean(opts.body) && !(opts.body instanceof FormData);
+      opts.headers = Object.assign({}, apiHeaders(wantsJson), options.headers || {});
+      const response = await fetch(url, opts);
+      if (response.status === 401 && retry){
+        const token = window.prompt('Enter API token');
+        if (!token) return response;
+        setApiToken(token);
+        const retryOpts = Object.assign({}, options);
+        retryOpts.headers = Object.assign({}, options.headers || {}, { 'X-API-Key': token });
+        return safeFetch(url, retryOpts, false);
+      }
+      return response;
+    }
+
+    function openModal(){ modal.style.display = 'flex'; }
+    function closeModal(){ modal.style.display = 'none'; form.reset(); }
+
+    async function refreshProjects(){
+      const res = await safeFetch('/ui/project_table');
+      if (res.ok){
+        tableBody.innerHTML = await res.text();
+      }
+    }
+
+    openBtn?.addEventListener('click', openModal);
+    closeBtn?.addEventListener('click', closeModal);
+    refreshBtn?.addEventListener('click', function(){ refreshProjects(); });
+
+    form?.addEventListener('submit', async function(ev){
+      ev.preventDefault();
+      const data = new FormData(form);
+      const payload = {};
+      data.forEach((value, key) => {
+        if (typeof value === 'string'){ const trimmed = value.trim(); if (trimmed) payload[key] = trimmed; }
+      });
+      const res = await safeFetch('/api/v1/projects', {
+        method: 'POST',
+        headers: apiHeaders(true),
+        body: JSON.stringify(payload),
+      });
+      if (res.ok){
+        closeModal();
+        await refreshProjects();
+      } else {
+        const detail = await res.json().catch(() => ({}));
+        window.alert(detail.detail || 'Unable to create project');
+      }
+    });
+
+    tableBody?.addEventListener('click', async function(ev){
+      const target = ev.target;
+      if (!(target instanceof HTMLElement)) return;
+      if (target.matches('[data-action="finalize-project"]')){
+        const projectId = target.getAttribute('data-project-id');
+        if (!projectId) return;
+        const confirmFinalize = window.confirm('Finalize this project and post its tickets to the main dashboard?');
+        if (!confirmFinalize) return;
+        const res = await safeFetch(`/api/v1/projects/${projectId}/finalize`, { method: 'POST' });
+        if (res.ok){
+          await refreshProjects();
+        } else {
+          const detail = await res.json().catch(() => ({}));
+          window.alert(detail.detail || 'Unable to finalize project');
+        }
+      }
+    });
+  })();
+  </script>
+</body>
+</html>

--- a/app/templates/reports.html
+++ b/app/templates/reports.html
@@ -119,6 +119,7 @@
       <nav class="links">
         <a href="/" class="pill">Dashboard</a>
         <a href="/tickets" class="pill">Tickets</a>
+        <a href="/projects" class="pill">Projects</a>
         <a href="/hardware" class="pill">Hardware</a>
         <a href="/inventory" class="pill">Inventory</a>
         <a href="/clients" class="pill">Clients</a>

--- a/app/templates/tickets.html
+++ b/app/templates/tickets.html
@@ -363,6 +363,7 @@
         <nav class="links">
           <a href="/" class="pill">Dashboard</a>
           <a href="/tickets" class="pill active" aria-current="page">Tickets</a>
+          <a href="/projects" class="pill">Projects</a>
           <a href="/hardware" class="pill">Hardware</a>
           <a href="/inventory" class="pill">Inventory</a>
           <a href="/clients" class="pill">Clients</a>

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -1,0 +1,71 @@
+"""Tests for project containers and staged ticket workflows."""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("DATA_DIR", str(ROOT / "data"))
+
+from app.db.session import Base
+from app.crud.projects import create_project, finalize_project, add_project_ticket
+from app.crud.tickets import list_project_tickets, list_tickets, get_ticket
+
+# Ensure models are registered so metadata tables are created
+from app.models import project as project_model  # noqa: F401
+from app.models import ticket as ticket_model  # noqa: F401
+
+
+@pytest.fixture()
+def db_session():
+    engine = create_engine("sqlite://", connect_args={"check_same_thread": False})
+    TestingSessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def test_project_finalize_posts_tickets(db_session):
+    project = create_project(
+        db_session,
+        {"name": "Office build", "client_key": "client_a", "client": "Client A"},
+    )
+    staged_ticket = add_project_ticket(
+        db_session,
+        project,
+        {
+            "start_iso": "2024-05-01T09:00:00",
+            "end_iso": "2024-05-01T11:00:00",
+            "client_key": "client_a",
+            "client": "Client A",
+            "note": "Rack install",
+        },
+    )
+
+    # Tickets linked to a project stay hidden from the main list until posted
+    visible_ticket_ids = [t.id for t in list_tickets(db_session)]
+    assert staged_ticket.id not in visible_ticket_ids
+
+    finalize_project(db_session, project)
+    refreshed = get_ticket(db_session, staged_ticket.id)
+    assert refreshed.project_posted == 1
+    assert refreshed.project_id == project.id
+
+    # Once finalised the ticket shows up in the main dashboard feed
+    visible_ticket_ids = [t.id for t in list_tickets(db_session)]
+    assert staged_ticket.id in visible_ticket_ids
+
+    project_tickets = list_project_tickets(db_session, project.id)
+    assert len(project_tickets) == 1
+    assert project_tickets[0].project_posted == 1
+    assert project.finalized_at is not None

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -30,6 +30,7 @@ from app.services.reporting import calculate_ticket_metrics
 
 # Ensure models are registered so metadata tables are created
 from app.models import ticket as ticket_model  # noqa: F401
+from app.models import project as project_model  # noqa: F401
 
 
 @pytest.fixture()

--- a/tests/test_tickets.py
+++ b/tests/test_tickets.py
@@ -32,6 +32,7 @@ from app.crud.tickets import (
 
 # Ensure models are registered so metadata tables are created
 from app.models import ticket as ticket_model  # noqa: F401
+from app.models import project as project_model  # noqa: F401
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary
- add project data model, migrations, CRUD helpers, and REST endpoints for managing project containers
- introduce a Projects dashboard with UI helpers to review and finalize staged tickets and update global navigation
- extend ticket schema/logic to support project-linked entries and cover the workflow with a new unit test

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915e4192e988332bf130df1c44f1836)